### PR TITLE
Inset index.html footer logo from the card edge

### DIFF
--- a/scripts/html_parts.py
+++ b/scripts/html_parts.py
@@ -167,7 +167,7 @@ thank_you_note = \
                     <div class="card bg-white mb-3" style="max-width: 500px; margin:auto">
                         <div class="row no-gutters">
                             <center><div class="col-md-4">
-                                <img src="_elements/logo.png" class="card-img" alt="DLEAPP logo">
+                                <img src="_elements/logo.png" class="card-img" alt="DLEAPP logo" style="padding:14px;">
                             </div>
                             <div class="col-md-8">
                             <div class="card-body">


### PR DESCRIPTION
## What
The logo in the index.html "Thank you for using DLEAPP" card sat flush against the top line of the card (Bootstrap `card-img` has no padding). Add a small **14px** inset so the logo is separated from the top (and edges) of the box.

## Change
- `scripts/html_parts.py`: add `style="padding:14px;"` to the footer card logo `<img>`.

Independent of #1 (banner resize); both target `main` and touch different lines of `html_parts.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)