### PR TITLE
Credit DLEAPP to Alexis Brignoni only

### DIFF
--- a/dleapp.py
+++ b/dleapp.py
@@ -348,8 +348,7 @@ def crunch_artifacts(
     logfunc('\n--------------------------------------------------------------------------------------')
     logfunc(f'DLEAPP v{dleapp_version}: DLEAPP Desktop, Logs, Events, and Protobuf Parser')
     logfunc('Objective: Triage desktop application artifacts (logs, events, and protobuf).')
-    logfunc('By: Alexis Brignoni | @AlexisBrignoni | abrignoni.com')
-    logfunc('By: Yogesh Khatri   | @SwiftForensics | swiftforensics.com\n')
+    logfunc('By: Alexis Brignoni | @AlexisBrignoni | abrignoni.com\n')
     
     seeker = None
     try:

--- a/scripts/version_info.py
+++ b/scripts/version_info.py
@@ -9,14 +9,4 @@ dleapp_version = '2.3.0-dev.0'
 
 dleapp_contributors = [
     ['Alexis Brignoni', 'https://abrignoni.com', '@AlexisBrignoni', 'https://github.com/abrignoni'],
-    ['Yogesh Khatri', 'https://swiftforensics.com', '@SwiftForensics', 'https://github.com/ydkhatri'],
-    ['Geraldine Blay', 'https://gforce4n6.blogspot.com', '@i_am_the_gia', 'https://github.com/gforce4n6'],
-    ['Kevin Pagano', 'https://stark4n6.com', '@KevinPagano3', 'https://github.com/stark4n6'],
-    ['Upintheairsheep2', '', '', 'https://github.com/upintheairsheep2'],
-    ['James Habben', 'https://4n6ir.com/', '@JamesHabben', 'https://github.com/JamesHabben'],
-    ['Evangelos Dragonas', 'https://atropos4n6.com/', '@theAtropos4n6', 'https://github.com/theAtropos4n6'],
-    ['Panos Nakoutis', '', '@4n6equals10', ''],
-    ['Johann Polewczyk', 'https://www.linkedin.com/in/johann-polewczyk-6a905425/',
-     '@johannplw', 'https://github.com/Johann-PLW'],
-    ['Christian Peter', 'https://cp-df.com', '@DasZamomin', 'https://github.com/prosch88'],
 ]


### PR DESCRIPTION
## What
Reduce the DLEAPP contributors to just Alexis Brignoni.

- `scripts/version_info.py`: trim `dleapp_contributors` to a single entry (Alexis Brignoni) — this drives the "DLEAPP contributors" list on the index.html page.
- `dleapp.py`: drop the carried-over co-author "By:" line from the run-log header so only Alexis is credited.

Verified by regenerating the report: index.html now shows only Alexis Brignoni in the credits and the run-log header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)