### PR TITLE
Give the DLEAPP GUI its own navy theme (not RLEAPP's)

### DIFF
--- a/dleappGUI.py
+++ b/dleappGUI.py
@@ -760,12 +760,12 @@ modules_filter_var = tk.StringVar()
 modules_filter_var.trace_add("write", filter_modules)  # Trigger filtering on input change
 pickModules()
 
-## Theme properties
-theme_bgcolor = '#248ea9'
-theme_inputcolor = '#aee7e8'
-theme_inputfgcolor = '#fdcb52'
-theme_fgcolor = '#fafdcb'
-theme_button = '#fafdcb'
+## Theme properties  (DLEAPP: Electron-Teal-on-Navy, matches the logo/report)
+theme_bgcolor = '#0E2438'      # deep navy base
+theme_inputcolor = '#D9EEF4'   # pale cyan input fields (black text)
+theme_inputfgcolor = '#45C4E0' # cyan accent
+theme_fgcolor = '#EAF6FB'      # near-white text on navy
+theme_button = '#2EC4B6'       # teal accent buttons (black text)
 
 if is_platform_macos():
     mlist_window_height = 24
@@ -811,7 +811,7 @@ style.map('TCombobox',
           fieldbackground=[('active', theme_inputcolor), ('readonly', theme_inputcolor)],
           )
 style.configure('TScrollbar', background=theme_button, arrowcolor='black', troughcolor=theme_inputcolor)
-style.configure('TProgressbar', thickness=4, background='DarkGreen')
+style.configure('TProgressbar', thickness=4, background=theme_button)
 
 ## Main Window Layout
 ### Top part of the window


### PR DESCRIPTION
## Why
The GUI theme colors were byte-identical to RLEAPP's (`#248ea9` teal). Each LEAPP uses a unique color, so DLEAPP should too.

## Change
Recolor the GUI to DLEAPP's existing **Electron-Teal-on-Navy** identity (same as the logo and HTML report):

| role | old (RLEAPP) | new (DLEAPP) |
|---|---|---|
| background | `#248ea9` teal | **`#0E2438` navy** |
| text | `#fafdcb` pale yellow | **`#EAF6FB` near-white** |
| inputs | `#aee7e8` | **`#D9EEF4` pale cyan** (black text) |
| buttons/accents | `#fafdcb` | **`#2EC4B6` teal** |
| progress bar | `DarkGreen` | **teal accent** |

Every widget already pairs the background with `theme_fgcolor` (labels, checkbuttons) or uses light inputs with black text, so contrast stays high on the dark background. `py_compile` clean.

Color preview (representative mock of the main window with the new palette) is in the PR discussion / attached in chat. Run `python dleappGUI.py` to see the real thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)