### PR TITLE
Fix PyInstaller specs: RLEAPP fork leftovers and CWD-dependent paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,8 @@ __pypackages__/
 *.mo
 *.manifest
 *.spec
+# ...except the hand-maintained PyInstaller build specs, which are source, not build output
+!scripts/pyinstaller/*.spec
 pip-wheel-metadata/
 share/python-wheels/
 wheels/

--- a/scripts/pyinstaller/dleapp.spec
+++ b/scripts/pyinstaller/dleapp.spec
@@ -1,9 +1,14 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import os
+
 block_cipher = None
 
+# PyInstaller resolves pathex and hookspath against the current working
+# directory, unlike the script and datas paths below, which it resolves against
+# the spec file. Anchor them to SPECPATH so the build works from any directory.
 a = Analysis(['..\\..\\dleapp.py'],
-             pathex=['..\\scripts\\artifacts'],
+             pathex=[os.path.join(SPECPATH, '..', 'artifacts')],
              binaries=[],
              datas=[('..\\', '.\\scripts')],
              hiddenimports=[
@@ -19,7 +24,7 @@ a = Analysis(['..\\..\\dleapp.py'],
                 'simplekml',
                 'xlrd',
                 ],
-             hookspath=['.\\'],
+             hookspath=[SPECPATH],
              runtime_hooks=[],
              excludes=[],
              win_no_prefer_redirects=False,

--- a/scripts/pyinstaller/dleapp.spec
+++ b/scripts/pyinstaller/dleapp.spec
@@ -1,0 +1,45 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(['..\\..\\dleapp.py'],
+             pathex=['..\\scripts\\artifacts'],
+             binaries=[],
+             datas=[('..\\', '.\\scripts')],
+             hiddenimports=[
+                'bencoding',
+                'fitz',
+                'ijson',
+                'mailbox',
+                'mammoth',
+                'openpyxl',
+                'pillow_heif',
+                'pypdf',
+                'requests',
+                'simplekml',
+                'xlrd',
+                ],
+             hookspath=['.\\'],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='dleapp',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          upx_exclude=[],
+          runtime_tmpdir=None,
+          version='dleapp-file_version_info.txt',
+          console=True )

--- a/scripts/pyinstaller/dleappGUI.spec
+++ b/scripts/pyinstaller/dleappGUI.spec
@@ -1,0 +1,47 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(['..\\..\\dleappGUI.py'],
+             pathex=['..\\scripts\\artifacts'],
+             binaries=[],
+             datas=[('..\\', '.\\scripts'), ('..\\..\\assets', '.\\assets')],
+             hiddenimports=[
+                'bencoding',
+                'fitz',
+                'ijson',
+                'mailbox',
+                'mammoth',
+                'openpyxl',
+                'pillow_heif',
+                'pypdf',
+                'requests',
+                'simplekml',
+                'xlrd',
+                ],
+             hookspath=['.\\'],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='dleappGUI',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          console=True,
+		    hide_console='hide-early',
+		    disable_windowed_traceback=False,
+          upx_exclude=[],
+          version='dleappGUI-file_version_info.txt',
+          runtime_tmpdir=None )

--- a/scripts/pyinstaller/dleappGUI.spec
+++ b/scripts/pyinstaller/dleappGUI.spec
@@ -1,9 +1,14 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import os
+
 block_cipher = None
 
+# PyInstaller resolves pathex and hookspath against the current working
+# directory, unlike the script and datas paths below, which it resolves against
+# the spec file. Anchor them to SPECPATH so the build works from any directory.
 a = Analysis(['..\\..\\dleappGUI.py'],
-             pathex=['..\\scripts\\artifacts'],
+             pathex=[os.path.join(SPECPATH, '..', 'artifacts')],
              binaries=[],
              datas=[('..\\', '.\\scripts'), ('..\\..\\assets', '.\\assets')],
              hiddenimports=[
@@ -19,7 +24,7 @@ a = Analysis(['..\\..\\dleappGUI.py'],
                 'simplekml',
                 'xlrd',
                 ],
-             hookspath=['.\\'],
+             hookspath=[SPECPATH],
              runtime_hooks=[],
              excludes=[],
              win_no_prefer_redirects=False,

--- a/scripts/pyinstaller/dleappGUI_macOS.spec
+++ b/scripts/pyinstaller/dleappGUI_macOS.spec
@@ -1,0 +1,61 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['../../dleappGUI.py'],
+    pathex=['scripts/artifacts'],
+    binaries=[],
+    datas=[('../', 'scripts'), ('../../assets', 'assets')],
+    hiddenimports=[
+        'bencoding',
+        'fitz',
+        'ijson',
+        'mailbox',
+        'mammoth',
+        'openpyxl',
+        'pillow_heif',
+        'pypdf',
+        'requests',
+        'xlrd',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='dleappGUI',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='dleappGUI',
+)
+app = BUNDLE(
+    coll,
+    name='dleappGUI.app',
+    icon='../../assets/icon.icns',
+    bundle_identifier='4n6.brigs.DLEAPP',
+    version='2.2.0',
+)

--- a/scripts/pyinstaller/dleappGUI_macOS.spec
+++ b/scripts/pyinstaller/dleappGUI_macOS.spec
@@ -1,9 +1,13 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import os
 
+# PyInstaller resolves pathex against the current working directory, unlike the
+# script and datas paths below, which it resolves against the spec file. Anchor
+# it to SPECPATH so the build works from any directory.
 a = Analysis(
     ['../../dleappGUI.py'],
-    pathex=['scripts/artifacts'],
+    pathex=[os.path.join(SPECPATH, '..', 'artifacts')],
     binaries=[],
     datas=[('../', 'scripts'), ('../../assets', 'assets')],
     hiddenimports=[

--- a/scripts/pyinstaller/dleapp_macOS.spec
+++ b/scripts/pyinstaller/dleapp_macOS.spec
@@ -1,0 +1,47 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+a = Analysis(
+    ['../../dleapp.py'],
+    pathex=['../scripts/artifacts'],
+    binaries=[],
+    datas=[('../', 'scripts')],
+    hiddenimports=[
+        'bencoding',
+        'fitz',
+        'ijson',
+        'mailbox',
+        'mammoth',
+        'openpyxl',
+        'pillow_heif',
+        'pypdf',
+        'requests',
+        'xlrd',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='dleapp',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/scripts/pyinstaller/dleapp_macOS.spec
+++ b/scripts/pyinstaller/dleapp_macOS.spec
@@ -1,8 +1,13 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import os
+
+# PyInstaller resolves pathex against the current working directory, unlike the
+# script and datas paths below, which it resolves against the spec file. Anchor
+# it to SPECPATH so the build works from any directory.
 a = Analysis(
     ['../../dleapp.py'],
-    pathex=['../scripts/artifacts'],
+    pathex=[os.path.join(SPECPATH, '..', 'artifacts')],
     binaries=[],
     datas=[('../', 'scripts')],
     hiddenimports=[


### PR DESCRIPTION
## Problem

All four PyInstaller specs under `scripts/pyinstaller/` were carried over from the RLEAPP fork unedited. None of them could produce a working build.

### 1. Fork leftovers

| Issue | Files |
|---|---|
| `Analysis()` pointed at `rleapp.py` / `rleappGUI.py` — these don't exist in this repo, so the build failed at the entry point | all four |
| `EXE`/`COLLECT`/`BUNDLE` names produced binaries called `rleapp` / `rleappGUI` | all four |
| `version=` pointed at `rleapp-file_version_info.txt` / `rleappGUI-file_version_info.txt`; the files on disk are named `dleapp-*` / `dleappGUI-*`, so the Windows version resource was silently never applied | `dleapp.spec`, `dleappGUI.spec` |
| macOS `.app` used `bundle_identifier='4n6.brigs.RLEAPP'` and `name='rleappGUI.app'` | `dleappGUI_macOS.spec` |

The two version-info txt files were checked and already carried the correct DLEAPP strings (`DLEAPP`, `dleapp.exe`, `dleappGUI.exe`) — no changes needed there.

### 2. CWD-dependent `pathex` / `hookspath`

PyInstaller resolves path arguments inconsistently:

| Spec argument | Resolved relative to |
|---|---|
| `Analysis([scripts])` | spec file's directory (`build_main.py:473`) |
| `datas` / `binaries` | spec file's directory (`workingdir=spec_dir`) |
| `pathex` | **current working directory** (`absnormpath` → `os.path.abspath`) |
| `hookspath` | **current working directory** (`expanduser` only) |

The inherited `pathex` values never accounted for that, and the two macOS specs disagreed about which directory you were supposed to build from:

- `'../scripts/artifacts'` (three specs) → `scripts/scripts/artifacts` from the spec dir, or outside the repo from the root. **Broken from either directory.**
- `'scripts/artifacts'` (`dleappGUI_macOS.spec`) → correct **only** when run from the repo root.

All four now anchor `pathex` to `SPECPATH`, so it resolves to `scripts/artifacts` no matter where `pyinstaller` is invoked. The Windows specs get the same treatment for `hookspath`, where `'.\'` only found `hook-plugin_loader.py` when the build ran from `scripts/pyinstaller/` — `[SPECPATH]` resolves to that same directory in that case and keeps working elsewhere.

A wrong `pathex` was never fatal (PyInstaller ignores non-existent search paths), so this half is a correctness fix rather than a build-breakage fix.

## The `.gitignore` change

These specs were **untracked**: the stock Python `.gitignore` ignores `*.spec` as PyInstaller build output, and `git log` confirms they were never committed. Since they're hand-maintained sources rather than generated files, this PR negates the pattern for `scripts/pyinstaller/` so they're version-controlled and this fix can't silently regress. Generated specs elsewhere stay ignored.

## Verification

Built both macOS specs with PyInstaller 6.21 (output directed outside the repo), **from the repo root** — a different directory than the specs previously assumed, which is what exercises the path fix:

- `dleapp_macOS.spec` → binary named `dleapp`, runs and prints `DLEAPP: Desktop, Logs, Events, and Protobuf Parser.`
- `dleappGUI_macOS.spec` → `dleappGUI.app` with `CFBundleIdentifier=4n6.brigs.DLEAPP`, `CFBundleExecutable=dleappGUI`
- `--log-level DEBUG` confirms the search path resolving to the real `scripts/artifacts`

The Windows specs can't be built on macOS. They were verified by Python syntax check, by confirming every referenced path resolves from `scripts/pyinstaller/`, and by executing the specs with stubbed PyInstaller globals to confirm `pathex` and `hookspath` both land on existing directories.

## Two things deliberately left alone

1. **Version drift** — the version-info txt files and the macOS `BUNDLE(version=...)` all say `2.2.0`, while `scripts/version_info.py` is at `2.3.0-dev.0`. Bumping release metadata to a dev version is a release-management call, not a build fix.
2. **macOS specs have `hookspath=[]`** — so `hook-plugin_loader.py` never runs on macOS, unlike on Windows. The macOS builds succeed anyway (the artifact modules ship via `datas` and are loaded at runtime), and populating it would change what gets bundled, so it's out of scope here. Worth a look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)