### PR TITLE
Add a Discord Desktop parser and reusable Chromium container readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,26 @@
 
 DLEAPP is also meant to be a home for parsers that don't fit neatly into any of the other LEAPPs — a place for desktop-application and other odds-and-ends artifacts to live rather than being forced into iLEAPP, ALEAPP, RLEAPP, and the like.
 
-The initial release ships a full **Wire** (app.wire.com desktop) parser — accounts, devices, conversations, messages, calls, attachments, cached assets, and media recovered by decrypting the app's cached asset blobs with the per-asset keys. More desktop-application parsers will be added over time.
+### Supported applications
+
+| Application | What is parsed |
+| --- | --- |
+| **Wire** (desktop) | Accounts, devices, conversations, messages, calls, attachments, cookies, service-worker cache, and media recovered by decrypting cached asset blobs. |
+| **Discord** (desktop) | Messages, attachments and recovered media, servers, channels, users, searches, reactions, message drafts, client activity, channel navigation, gateway sessions, account and application details, and a full cache index. |
+
+Discord Desktop keeps no message database of its own: the client renders from
+REST API responses, and those responses stay in the Chromium HTTP cache. The
+Discord artifacts read that cache directly, so messages, attachments and the
+images themselves are recoverable after they were deleted server-side. The
+approach follows Alex Caithness's work on treating a web app's browser
+artifacts as an application in their own right
+([browser-forensics-presentation-2025](https://github.com/cclgroupltd/browser-forensics-presentation-2025),
+[mister-skinnylegs](https://github.com/cclgroupltd/mister-skinnylegs)).
+
+The Chromium container formats these parsers rely on live in `scripts/chromium/`
+(Simple Cache reader, Local Storage LevelDB reader) and are reusable by any
+future Electron application parser. More desktop-application parsers will be
+added over time.
 
 If you want to contribute hit me up on twitter: https://twitter.com/AlexisBrignoni   
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 beautifulsoup4==4.8.2
 bencoding
+Brotli
 ijson
 mammoth
 openpyxl

--- a/scripts/artifacts/discordAccount.py
+++ b/scripts/artifacts/discordAccount.py
@@ -1,0 +1,175 @@
+__artifacts_v2__ = {
+    "discordAccount": {
+        "name": "Discord Account & Application",
+        "description": "The account signed in to Discord Desktop together with "
+                       "the application, device and operating system details the "
+                       "client recorded about the machine it was running on. The "
+                       "Sentry crash-reporting scope is the richest single "
+                       "source: it names the account, the app build and the "
+                       "hardware, and it is written on every run.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "Reads sentry/scope_v3.json, settings.json, Preferences, "
+                 "Local State, ShipIt_request.json and the account stores in "
+                 "Local Storage. Authentication tokens are reported as present "
+                 "or absent, never printed.",
+        "paths": (
+            '*/discord*/sentry/scope_v3.json',
+            '*/discord*/settings.json',
+            '*/discord*/Preferences',
+            '*/discord*/Local State',
+            '*/discord*/ShipIt_request.json',
+            '*/discord*/Local Storage/leveldb/*',
+        ),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "user",
+    },
+}
+
+import json
+import os
+
+from scripts.chromium import discord_api
+from scripts.chromium.local_storage import leveldb_folders, read_records
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+# Sentry context blocks worth surfacing, and the fields to take from each.
+_CONTEXT_FIELDS = {
+    "app": [("app_name", "Application"), ("app_version", "Application Version"),
+            ("app_arch", "Application Architecture"),
+            ("app_start_time", "Application Start Time")],
+    "device": [("family", "Device Family"), ("arch", "Device Architecture"),
+               ("cpu_description", "CPU"), ("processor_count", "CPU Cores"),
+               ("memory_size", "Memory (bytes)"), ("boot_time", "Device Boot Time")],
+    "os": [("name", "Operating System"), ("version", "OS Version"),
+           ("build", "OS Build"), ("kernel_version", "Kernel Version")],
+    "runtime": [("name", "Runtime"), ("version", "Runtime Version")],
+    "chrome": [("version", "Chromium Version")],
+    "node": [("version", "Node.js Version")],
+    "culture": [("locale", "Locale"), ("timezone", "Time Zone")],
+}
+
+
+def _read_json(path):
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            return json.load(handle)
+    except (OSError, ValueError):
+        return None
+
+
+@artifact_processor
+def discordAccount(context):
+    data_headers = ("Property", "Value", "Source File")
+    data_list = []
+    source_path = ""
+    files_found = [str(f) for f in context.get_files_found()]
+
+    def add(prop, value, path):
+        if value not in (None, "", [], {}):
+            data_list.append((prop, str(value), context.get_relative_path(path)))
+
+    for file_found in files_found:
+        name = os.path.basename(file_found)
+
+        if name == "scope_v3.json":
+            scope = _read_json(file_found)
+            if not scope:
+                continue
+            source_path = source_path or file_found
+            user = (scope.get("scope") or {}).get("user") or {}
+            add("Account ID", user.get("id"), file_found)
+            add("Username", user.get("username"), file_found)
+            add("Email Address", user.get("email"), file_found)
+            add("Account Created", discord_api.snowflake_to_datetime(user.get("id")),
+                file_found)
+
+            event = scope.get("event") or {}
+            contexts = event.get("contexts") or {}
+            for block, fields in _CONTEXT_FIELDS.items():
+                values = contexts.get(block) or {}
+                for key, label in fields:
+                    add(label, values.get(key), file_found)
+            add("Release", event.get("release"), file_found)
+            add("Environment", event.get("environment"), file_found)
+            add("Native Build Number",
+                ((scope.get("scope") or {}).get("tags") or {}).get("nativeBuildNumber"),
+                file_found)
+
+        elif name == "settings.json":
+            settings = _read_json(file_found)
+            if not isinstance(settings, dict):
+                continue
+            source_path = source_path or file_found
+            bounds = settings.get("WINDOW_BOUNDS") or {}
+            if bounds:
+                add("Window Bounds",
+                    f"x={bounds.get('x')} y={bounds.get('y')} "
+                    f"{bounds.get('width')}x{bounds.get('height')}", file_found)
+            for key in ("enableHardwareAcceleration", "openH264Enabled",
+                        "MinimizeToTray", "OPEN_ON_STARTUP", "START_MINIMIZED",
+                        "SKIP_HOST_UPDATE", "IS_MAXIMIZED", "IS_MINIMIZED"):
+                if key in settings:
+                    add(f"Setting: {key}", settings[key], file_found)
+
+        elif name == "Preferences":
+            prefs = _read_json(file_found)
+            if not isinstance(prefs, dict):
+                continue
+            source_path = source_path or file_found
+            dictionaries = ((prefs.get("spellcheck") or {}).get("dictionaries") or [])
+            add("Spellcheck Dictionaries", ", ".join(dictionaries), file_found)
+            salt = ((prefs.get("electron") or {}).get("media") or {}).get("device_id_salt")
+            add("Media Device ID Salt", salt, file_found)
+
+        elif name == "ShipIt_request.json":
+            request = _read_json(file_found)
+            if not isinstance(request, dict):
+                continue
+            source_path = source_path or file_found
+            add("Installed Bundle", request.get("targetBundleURL"), file_found)
+            add("Update Bundle", request.get("updateBundleURL"), file_found)
+            add("Bundle Identifier", request.get("bundleIdentifier"), file_found)
+
+    for folder in leveldb_folders(files_found):
+        try:
+            records = sorted(read_records(folder), key=lambda r: -r.sequence)
+        except Exception as ex:
+            logfunc(f"Discord Account: could not read Local Storage '{folder}': {ex}")
+            continue
+        source_path = source_path or folder
+        reported = set()
+        for record in records:
+            if record.key in reported or not record.is_live:
+                continue
+            if record.key == "MultiAccountStore":
+                try:
+                    users = (json.loads(record.value).get("_state") or {}).get("users") or []
+                except ValueError:
+                    continue
+                reported.add(record.key)
+                for user in users:
+                    label = user.get("username") or user.get("id")
+                    add(f"Local Storage Account: {label}",
+                        f"id={user.get('id')} discriminator={user.get('discriminator')}",
+                        record.source)
+            elif record.key == "tokens":
+                try:
+                    tokens = json.loads(record.value)
+                except ValueError:
+                    continue
+                reported.add(record.key)
+                # The token itself is a live credential; report only its presence.
+                for token_key in tokens:
+                    add("Authentication Token Stored For",
+                        token_key if token_key.isdigit() else f"{token_key} (client)",
+                        record.source)
+            elif record.key == "fingerprint" and record.value:
+                reported.add(record.key)
+                add("Client Fingerprint", record.value.strip('"'), record.source)
+
+    logfunc(f"Discord Account & Application: {len(data_list)} property value(s).")
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/discordAccount.py
+++ b/scripts/artifacts/discordAccount.py
@@ -2,8 +2,14 @@ __artifacts_v2__ = {
     "discordAccount": {
         "name": "Discord Account & Application",
         "description": "The account signed in to Discord Desktop together with "
-                       "the application, device and operating system details the "
-                       "client recorded about the machine it was running on. The "
+                       "the application, device and operating system values the "
+                       "client itself recorded about the machine it was running "
+                       "on. They identify the installation that the other "
+                       "artifacts in this category were parsed from. The "
+                       "time zone recorded here is the one the log-derived "
+                       "artifacts (Channel Navigation, Gateway Sessions) must "
+                       "be read against, since those are written in device "
+                       "local time. The "
                        "Sentry crash-reporting scope is the richest single "
                        "source: it names the account, the app build and the "
                        "hardware, and it is written on every run.",

--- a/scripts/artifacts/discordCacheRecords.py
+++ b/scripts/artifacts/discordCacheRecords.py
@@ -1,0 +1,71 @@
+__artifacts_v2__ = {
+    "discordCacheRecords": {
+        "name": "Discord Cache Records",
+        "description": "Index of every response held in the Discord Desktop "
+                       "HTTP cache, with the time the client requested it and "
+                       "the time the response was stored. Discord has no "
+                       "browsing history database, so this index is the closest "
+                       "equivalent: it shows which API calls, CDN images, "
+                       "embedded links and third-party resources the client "
+                       "fetched, and when.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "Versioned application bundle assets (js, css, fonts, icons) "
+                 "are excluded because they carry no investigative value and "
+                 "dominate the cache by volume. Everything else is listed, "
+                 "including link previews fetched from sites outside Discord.",
+        "paths": (
+            '*/discord*/Cache/Cache_Data/*_0',
+            '*/discord*/Service Worker/CacheStorage/*/*/*_0',
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "list",
+    },
+}
+
+from datetime import datetime, timezone
+
+from scripts.chromium import discord_api
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_EPOCH_MIN = datetime.min.replace(tzinfo=timezone.utc)
+
+
+@artifact_processor
+def discordCacheRecords(context):
+    data_headers = (
+        ("Requested", "datetime"), ("Cached", "datetime"), "Host", "Path",
+        "Query", "Media Kind", "HTTP Status", "Content Type",
+        "Body Size (bytes)", "URL", "Source Cache File",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    scan = discord_api.scan_cache(files_found, log=logfunc)
+    if not scan.records:
+        return data_headers, [], ""
+
+    data_list = []
+    for record in scan.records:
+        data_list.append((
+            record["requested"],
+            record["cached"],
+            record["host"],
+            record["path"],
+            record["query"],
+            record["kind"],
+            record["status"] if record["status"] is not None else "",
+            record["content_type"],
+            record["size"],
+            record["url"],
+            context.get_relative_path(record["source"]),
+        ))
+
+    data_list.sort(key=lambda row: row[0] if isinstance(row[0], datetime) else _EPOCH_MIN,
+                   reverse=True)
+    logfunc(f"Discord Cache Records: {len(data_list)} cached response(s) indexed "
+            f"of {scan.entry_count} total cache entries.")
+    return data_headers, data_list, "\n".join(
+        sorted({r["source"] for r in scan.records})[:50])

--- a/scripts/artifacts/discordCacheRecords.py
+++ b/scripts/artifacts/discordCacheRecords.py
@@ -7,7 +7,11 @@ __artifacts_v2__ = {
                        "browsing history database, so this index is the closest "
                        "equivalent: it shows which API calls, CDN images, "
                        "embedded links and third-party resources the client "
-                       "fetched, and when.",
+                       "fetched, and when. Hosts outside Discord appear too, "
+                       "since the client fetches link previews and embedded "
+                       "media from them. The cache evicts over time, so this "
+                       "index is a partial record of what the client fetched "
+                       "rather than a complete one.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",

--- a/scripts/artifacts/discordContacts.py
+++ b/scripts/artifacts/discordContacts.py
@@ -4,19 +4,24 @@ __artifacts_v2__ = {
         "description": "Every Discord account observed anywhere in the cached "
                        "application data: message authors, mentioned users, "
                        "direct message recipients, people who reacted to a "
-                       "message, invite creators and viewed profiles. User IDs "
+                       "message, invite creators and cached profiles. User IDs "
                        "are snowflakes, so each account's registration date is "
                        "recoverable, and a cached avatar is embedded where one "
-                       "survives.",
+                       "survives. Where a profile response was cached, the "
+                       "external accounts Discord recorded as connected to it "
+                       "(Steam, Spotify, Xbox and similar) are listed with "
+                       "their platform and account name. First and last seen "
+                       "describe the surviving cached evidence, not the "
+                       "account's activity window.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "Discord (Desktop)",
-        "notes": "First and last seen reflect the cached evidence, not the "
-                 "account's real activity window. Profile fields (bio, pronouns, "
-                 "connected accounts) are only present for profiles the user "
-                 "actually opened in the client.",
+        "notes": "Profile fields (bio, pronouns, connected accounts) are only "
+                 "present where a profile response was cached, so a sparse row "
+                 "means no profile response survives, not that the account has "
+                 "no profile.",
         "paths": (
             '*/discord*/Cache/Cache_Data/*_0',
             '*/discord*/Service Worker/CacheStorage/*/*/*_0',
@@ -32,7 +37,10 @@ __artifacts_v2__ = {
                        "the cached data, with the number of messages recovered "
                        "for each and the span those messages cover. Channel IDs "
                        "are snowflakes, so the channel creation date is "
-                       "recoverable even for a channel only seen once in a URL.",
+                       "recoverable even for a channel only seen once in a URL. "
+                       "The message count is what survived in the cache rather "
+                       "than the volume of the conversation, and the date span "
+                       "covers only the recovered messages.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
@@ -58,18 +66,23 @@ __artifacts_v2__ = {
         "description": "Discord servers (guilds) the client encountered, built "
                        "from cached server profiles, invite lookups, the server "
                        "IDs attached to cached channels and the servers the "
-                       "renderer log shows the user navigating to. Server IDs "
+                       "renderer log shows the client routing to. Server IDs "
                        "are snowflakes, so the server's creation date is "
-                       "recoverable even when only the ID survives.",
+                       "recoverable even when only the ID survives. A server is "
+                       "listed because its ID or profile appeared in cached "
+                       "data or in the navigation log. That records the client "
+                       "encountering the server and does not establish "
+                       "membership, since an invite lookup produces a record "
+                       "for a server that was never joined.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "Discord (Desktop)",
-        "notes": "A server appearing here means the client saw it, which "
-                 "includes servers reached through an invite link without ever "
-                 "joining. Member counts are the approximate values Discord "
-                 "returned at the time the response was cached.",
+        "notes": "Member counts are the approximate values Discord returned at "
+                 "the time the response was cached, not current figures. "
+                 "Channel and message counts are limited to what the cache and "
+                 "the navigation log revealed about each server.",
         "paths": (
             '*/discord*/Cache/Cache_Data/*_0',
             '*/discord*/Service Worker/CacheStorage/*/*/*_0',
@@ -84,16 +97,19 @@ __artifacts_v2__ = {
         "description": "Server invite links the client looked up. Discord "
                        "resolves an invite code through the API before showing "
                        "the join prompt, and that response names the server, the "
-                       "channel the invite points at, who created it and when it "
-                       "expires.",
+                       "channel the invite points at, who created it and when "
+                       "it expires. A row records that the client resolved that "
+                       "invite code and what Discord returned for it. It does "
+                       "not establish that the user joined the server.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "Discord (Desktop)",
-        "notes": "An invite appearing here shows the link was opened or "
-                 "previewed in the client. It does not establish that the user "
-                 "joined the server.",
+        "notes": "One row per invite code, from the most recent cached lookup. "
+                 "The expiry is the value Discord returned when the code was "
+                 "resolved, so an expired invite may still have been valid when "
+                 "it was used.",
         "paths": (
             '*/discord*/Cache/Cache_Data/*_0',
             '*/discord*/Service Worker/CacheStorage/*/*/*_0',

--- a/scripts/artifacts/discordContacts.py
+++ b/scripts/artifacts/discordContacts.py
@@ -1,0 +1,411 @@
+__artifacts_v2__ = {
+    "discordUsers": {
+        "name": "Discord Users Seen",
+        "description": "Every Discord account observed anywhere in the cached "
+                       "application data: message authors, mentioned users, "
+                       "direct message recipients, people who reacted to a "
+                       "message, invite creators and viewed profiles. User IDs "
+                       "are snowflakes, so each account's registration date is "
+                       "recoverable, and a cached avatar is embedded where one "
+                       "survives.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "First and last seen reflect the cached evidence, not the "
+                 "account's real activity window. Profile fields (bio, pronouns, "
+                 "connected accounts) are only present for profiles the user "
+                 "actually opened in the client.",
+        "paths": (
+            '*/discord*/Cache/Cache_Data/*_0',
+            '*/discord*/Service Worker/CacheStorage/*/*/*_0',
+            '*/discord*/sentry/scope_v3.json',
+            '*/discord*/Local Storage/leveldb/*',
+        ),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "users",
+    },
+    "discordChannels": {
+        "name": "Discord Channels",
+        "description": "Channels, direct messages and group chats referenced by "
+                       "the cached data, with the number of messages recovered "
+                       "for each and the span those messages cover. Channel IDs "
+                       "are snowflakes, so the channel creation date is "
+                       "recoverable even for a channel only seen once in a URL.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "Channel names and topics are only known where the client "
+                 "cached a channel object or a search response describing them; "
+                 "otherwise only the ID is reported. The server a channel "
+                 "belongs to is resolved from cached channel objects, the "
+                 "renderer log's routing entries and the Local Storage channel "
+                 "selection state.",
+        "paths": (
+            '*/discord*/Cache/Cache_Data/*_0',
+            '*/discord*/Service Worker/CacheStorage/*/*/*_0',
+            '*/discord*/logs/renderer_js*.log',
+            '*/discord*/Local Storage/leveldb/*',
+        ),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "hash",
+    },
+    "discordGuilds": {
+        "name": "Discord Servers",
+        "description": "Discord servers (guilds) the client encountered, built "
+                       "from cached server profiles, invite lookups, the server "
+                       "IDs attached to cached channels and the servers the "
+                       "renderer log shows the user navigating to. Server IDs "
+                       "are snowflakes, so the server's creation date is "
+                       "recoverable even when only the ID survives.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "A server appearing here means the client saw it, which "
+                 "includes servers reached through an invite link without ever "
+                 "joining. Member counts are the approximate values Discord "
+                 "returned at the time the response was cached.",
+        "paths": (
+            '*/discord*/Cache/Cache_Data/*_0',
+            '*/discord*/Service Worker/CacheStorage/*/*/*_0',
+            '*/discord*/logs/renderer_js*.log',
+            '*/discord*/Local Storage/leveldb/*',
+        ),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "server",
+    },
+    "discordInvites": {
+        "name": "Discord Invites",
+        "description": "Server invite links the client looked up. Discord "
+                       "resolves an invite code through the API before showing "
+                       "the join prompt, and that response names the server, the "
+                       "channel the invite points at, who created it and when it "
+                       "expires.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "An invite appearing here shows the link was opened or "
+                 "previewed in the client. It does not establish that the user "
+                 "joined the server.",
+        "paths": (
+            '*/discord*/Cache/Cache_Data/*_0',
+            '*/discord*/Service Worker/CacheStorage/*/*/*_0',
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "link",
+    },
+}
+
+import json
+import os
+import re
+from datetime import datetime
+
+from scripts.chromium import discord_api
+from scripts.chromium.local_storage import leveldb_folders, read_records
+from scripts.chromium.simple_cache import read_entry
+from scripts.ilapfuncs import artifact_processor, check_in_embedded_media, logfunc
+
+_ROUTE_RE = re.compile(r"Transitioning to /channels/(\d+)/(\d+)")
+
+
+def _channel_to_server(scan, files_found):
+    """Map channel id -> server id, from every source that records the pairing.
+
+    Cached channel objects carry a guild_id, but most channels are only ever
+    seen as an ID in a message. The renderer log's routing entries and the
+    Local Storage channel selection state both pair a channel with its server,
+    which fills in almost everything the user actually visited.
+    """
+    mapping = {}
+    for channel_id, channel in scan.channels.items():
+        if channel.get("guild_id"):
+            mapping[channel_id] = str(channel["guild_id"])
+
+    for file_found in files_found:
+        file_found = str(file_found)
+        if "renderer_js" not in os.path.basename(file_found):
+            continue
+        try:
+            with open(file_found, "r", encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    match = _ROUTE_RE.search(line)
+                    if match:
+                        mapping.setdefault(match.group(2), match.group(1))
+        except OSError:
+            continue
+
+    for folder in leveldb_folders(files_found):
+        try:
+            records = list(read_records(folder))
+        except Exception:
+            continue
+        for record in records:
+            if record.key != "SelectedChannelStore":
+                continue
+            try:
+                state = json.loads(record.value)
+            except (ValueError, TypeError):
+                continue
+            for field in ("selectedChannelIds", "mostRecentSelectedTextChannelIds"):
+                for guild_id, channel_id in (state.get(field) or {}).items():
+                    if guild_id and guild_id != "null" and channel_id:
+                        mapping.setdefault(str(channel_id), str(guild_id))
+    return mapping
+
+
+def _best_avatars(scan):
+    """Map user id -> the largest cached avatar for that user."""
+    best = {}
+    for path, media in scan.media.items():
+        if media["kind"] not in ("Avatar", "Guild Avatar") or not media["owner_id"]:
+            continue
+        current = best.get(media["owner_id"])
+        if current is None or media["size"] > current[1]["size"]:
+            best[media["owner_id"]] = (path, media)
+    return best
+
+
+def _avatar_reference(avatars, user_id):
+    """Embed the largest cached avatar for a user, if one is cached."""
+    best = avatars.get(user_id)
+    if best is None:
+        return None
+    entry = read_entry(best[0])
+    if entry is None:
+        return None
+    body = entry.decoded_body()
+    if not body:
+        return None
+    content_type = (best[1].get("content_type") or "").split(";")[0].strip()
+    return check_in_embedded_media(
+        best[0], body, f"avatar_{user_id}",
+        force_type=content_type or None,
+        force_extension=content_type.split("/")[-1] if "/" in content_type else None)
+
+
+@artifact_processor
+def discordUsers(context):
+    data_headers = (
+        "Username", "Display Name", ("Avatar", "media"), "User ID",
+        ("Account Created", "datetime"), "Bot", "Private Note", "Pronouns",
+        "Bio", "Legacy Username", "Connected Accounts", "Mutual Servers",
+        "Seen As", ("First Seen (Cached)", "datetime"),
+        ("Last Seen (Cached)", "datetime"), "Profile Cached",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    scan = discord_api.scan_cache(files_found, log=logfunc)
+    if not scan.users:
+        return data_headers, [], ""
+
+    account = discord_api.find_local_account(files_found)
+    local_ids = account["ids"]
+    avatars = _best_avatars(scan)
+    # Private notes the local user wrote about another account.
+    notes = {note["user_id"]: note["note"] for note in scan.notes}
+
+    data_list = []
+    for user_id, user in scan.users.items():
+        profile = (scan.profiles.get(user_id) or {}).get("profile") or {}
+        profile_user = profile.get("user") or {}
+        user_profile = profile.get("user_profile") or {}
+        connections = ", ".join(
+            f"{c.get('type')}:{c.get('name')}" for c in (profile.get("connected_accounts") or [])
+            if isinstance(c, dict))
+        mutual = ", ".join(
+            (scan.guilds.get(str(g.get("id")), {}).get("name") or str(g.get("id", "")))
+            for g in (profile.get("mutual_guilds") or []) if isinstance(g, dict))
+
+        username = user["username"] or profile_user.get("username", "")
+        if user_id in local_ids:
+            username = f"{username} (local account)" if username else "(local account)"
+
+        data_list.append((
+            username,
+            user["global_name"] or profile_user.get("global_name", ""),
+            _avatar_reference(avatars, user_id),
+            user_id,
+            discord_api.snowflake_to_datetime(user_id),
+            "Yes" if user["bot"] else "",
+            notes.get(user_id, ""),
+            user_profile.get("pronouns", ""),
+            (profile_user.get("bio") or user_profile.get("bio") or "").strip(),
+            profile.get("legacy_username", ""),
+            connections,
+            mutual,
+            ", ".join(sorted(user["seen_in"])),
+            user["first_seen"],
+            user["last_seen"],
+            "Yes" if profile else "",
+        ))
+
+    data_list.sort(key=lambda row: (row[0] or "").lower())
+    logfunc(f"Discord Users Seen: {len(data_list)} account(s), "
+            f"{len(scan.profiles)} with a cached profile.")
+    return data_headers, data_list, "\n".join(sorted(scan.source_paths)[:50])
+
+
+@artifact_processor
+def discordChannels(context):
+    data_headers = (
+        "Channel", "Server", "Type", "Messages Recovered",
+        ("First Message", "datetime"), ("Last Message", "datetime"),
+        "Participants", "Topic", "Channel ID", "Server ID",
+        ("Channel Created", "datetime"), "Parent Channel ID",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    scan = discord_api.scan_cache(files_found, log=logfunc)
+    if not scan.channels:
+        return data_headers, [], ""
+
+    servers = _channel_to_server(scan, files_found)
+    counts = {}
+    spans = {}
+    for wrapper in scan.messages.values():
+        message = wrapper["message"]
+        channel_id = str(message.get("channel_id") or "")
+        if not channel_id:
+            continue
+        counts[channel_id] = counts.get(channel_id, 0) + 1
+        sent = discord_api.iso_to_datetime(message.get("timestamp")) \
+            or discord_api.snowflake_to_datetime(message.get("id"))
+        if isinstance(sent, datetime):
+            first, last = spans.get(channel_id, (sent, sent))
+            spans[channel_id] = (min(first, sent), max(last, sent))
+
+    data_list = []
+    for channel_id, channel in scan.channels.items():
+        first, last = spans.get(channel_id, ("", ""))
+        name = channel["name"]
+        if name:
+            name = f"#{name}"
+        elif channel["recipients"]:
+            name = channel["recipients"]
+        guild_id = channel["guild_id"] or servers.get(channel_id, "")
+        guild = scan.guilds.get(guild_id) or {}
+        data_list.append((
+            name or channel_id,
+            guild.get("name") or guild_id,
+            discord_api.channel_type_name(channel["type"]),
+            counts.get(channel_id, 0),
+            first,
+            last,
+            channel["recipients"],
+            channel["topic"] or "",
+            channel_id,
+            guild_id,
+            discord_api.snowflake_to_datetime(channel_id),
+            channel["parent_id"],
+        ))
+
+    data_list.sort(key=lambda row: (-row[3], (row[0] or "").lower()))
+    logfunc(f"Discord Channels: {len(data_list)} channel(s) referenced.")
+    return data_headers, data_list, "\n".join(sorted(scan.source_paths)[:50])
+
+
+@artifact_processor
+def discordGuilds(context):
+    data_headers = (
+        "Server", "Description", "Members (approx.)", "Channels Seen",
+        "Messages Recovered", ("Server Created", "datetime"), "Server ID",
+        "Vanity URL", "Features", "Source Cache File",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    scan = discord_api.scan_cache(files_found, log=logfunc)
+    if not scan.guilds:
+        return data_headers, [], ""
+
+    channel_to_guild = _channel_to_server(scan, files_found)
+    channel_counts = {}
+    message_counts = {}
+    for guild_id in channel_to_guild.values():
+        channel_counts[guild_id] = channel_counts.get(guild_id, 0) + 1
+    for wrapper in scan.messages.values():
+        guild_id = channel_to_guild.get(str(wrapper["message"].get("channel_id") or ""))
+        if guild_id:
+            message_counts[guild_id] = message_counts.get(guild_id, 0) + 1
+
+    # Servers only ever seen as an ID in a route or channel mapping still count.
+    known = dict(scan.guilds)
+    for guild_id in channel_to_guild.values():
+        known.setdefault(guild_id, {
+            "id": guild_id, "name": "", "description": "", "member_count": None,
+            "features": "", "vanity_url": "", "icon": "",
+            "source": "channel and navigation references",
+        })
+
+    data_list = []
+    for guild_id, guild in known.items():
+        data_list.append((
+            guild["name"] or guild_id,
+            guild["description"] or "",
+            guild["member_count"] if guild["member_count"] is not None else "",
+            channel_counts.get(guild_id, 0),
+            message_counts.get(guild_id, 0),
+            discord_api.snowflake_to_datetime(guild_id),
+            guild_id,
+            guild["vanity_url"],
+            guild["features"],
+            context.get_relative_path(guild["source"]),
+        ))
+
+    data_list.sort(key=lambda row: (row[0] or "").lower())
+    logfunc(f"Discord Servers: {len(data_list)} server(s) referenced.")
+    return data_headers, data_list, "\n".join(sorted(scan.source_paths)[:50])
+
+
+@artifact_processor
+def discordInvites(context):
+    data_headers = (
+        ("Looked Up", "datetime"), "Invite Code", "Server", "Target Channel",
+        "Created By", "Members (approx.)", "Online (approx.)",
+        ("Invite Expires", "datetime"), "Server ID", "Channel ID",
+        "Inviter ID", "Source Cache File",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    scan = discord_api.scan_cache(files_found, log=logfunc)
+    if not scan.invites:
+        return data_headers, [], ""
+
+    data_list = []
+    seen = set()
+    for record in scan.invites:
+        invite = record["invite"]
+        code = invite.get("code", "")
+        if code in seen:
+            continue
+        seen.add(code)
+        guild = invite.get("guild") or {}
+        channel = invite.get("channel") or {}
+        inviter = invite.get("inviter") or {}
+        channel_name = channel.get("name") or ""
+        data_list.append((
+            record["cached"],
+            code,
+            guild.get("name") or str(guild.get("id") or ""),
+            f"#{channel_name}" if channel_name else str(channel.get("id") or ""),
+            discord_api.user_display(inviter),
+            invite.get("approximate_member_count", ""),
+            invite.get("approximate_presence_count", ""),
+            discord_api.iso_to_datetime(invite.get("expires_at")),
+            str(guild.get("id") or ""),
+            str(channel.get("id") or ""),
+            str(inviter.get("id") or ""),
+            context.get_relative_path(record["source"]),
+        ))
+
+    data_list.sort(key=lambda row: row[0] if isinstance(row[0], datetime) else datetime.min)
+    logfunc(f"Discord Invites: {len(data_list)} invite lookup(s) recovered.")
+    return data_headers, data_list, "\n".join(
+        sorted({r["source"] for r in scan.invites})[:50])

--- a/scripts/artifacts/discordLocalStorage.py
+++ b/scripts/artifacts/discordLocalStorage.py
@@ -1,0 +1,247 @@
+__artifacts_v2__ = {
+    "discordDrafts": {
+        "name": "Discord Message Drafts",
+        "description": "Unsent message drafts held in Local Storage. Discord "
+                       "saves the draft box as the user types, and Local Storage "
+                       "is a LevelDB, so superseded versions of the key stay on "
+                       "disk. The result is a keystroke-level history of "
+                       "messages that were composed but never sent, each with "
+                       "its own timestamp and target channel.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "Rows come from every surviving version of the DraftStore key, "
+                 "so the same draft usually appears several times as it grew. "
+                 "The highest sequence number is the most recent version.",
+        "paths": ('*/discord*/Local Storage/leveldb/*',),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "edit-3",
+    },
+    "discordActivity": {
+        "name": "Discord Client Activity",
+        "description": "Application usage reconstructed from the Local Storage "
+                       "state Discord keeps between runs: channels opened and "
+                       "when, servers selected, voice channels joined, quick "
+                       "switcher history and client session heartbeats. This is "
+                       "usage evidence that exists independently of any message "
+                       "content.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "Channel-open events come from the frecency store, which keeps "
+                 "a rolling window of recent usages; older versions of the key "
+                 "extend that window further back. Entries without a stored "
+                 "timestamp are reported in order with no time.",
+        "paths": ('*/discord*/Local Storage/leveldb/*',),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "activity",
+    },
+    "discordLocalStorage": {
+        "name": "Discord Local Storage",
+        "description": "Raw Local Storage keys and values for the Discord "
+                       "origins, including superseded and deleted versions "
+                       "recovered from the LevelDB table and log files. Use this "
+                       "when a store is not yet parsed into its own artifact.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "Values are truncated in the report at 5,000 characters. "
+                 "Authentication token values are redacted.",
+        "paths": ('*/discord*/Local Storage/leveldb/*',),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "database",
+    },
+}
+
+import json
+from datetime import datetime, timezone
+
+from scripts.chromium import discord_api
+from scripts.chromium.local_storage import leveldb_folders, read_records
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_VALUE_LIMIT = 5000
+_EPOCH_MIN = datetime.min.replace(tzinfo=timezone.utc)
+_REDACTED_KEYS = {"tokens"}
+
+
+def _records(context):
+    """All Local Storage records for the Discord origins, newest sequence first."""
+    records = []
+    for folder in leveldb_folders([str(f) for f in context.get_files_found()]):
+        try:
+            records.extend(read_records(folder))
+        except Exception as ex:
+            logfunc(f"Discord Local Storage: could not read '{folder}': {ex}")
+    records.sort(key=lambda record: -record.sequence)
+    return records
+
+
+def _load_state(record):
+    try:
+        payload = json.loads(record.value)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload.get("_state", payload)
+
+
+@artifact_processor
+def discordDrafts(context):
+    data_headers = (
+        ("Draft Saved", "datetime"), "Draft Text", "Channel ID", "Account ID",
+        "Draft Type", "LevelDB Sequence", "Record State", "Source File",
+    )
+
+    data_list = []
+    seen = set()
+    source_path = ""
+    for record in _records(context):
+        if record.key != "DraftStore":
+            continue
+        state = _load_state(record)
+        if not isinstance(state, dict):
+            continue
+        source_path = source_path or record.source
+        for account_id, channels in state.items():
+            if not isinstance(channels, dict):
+                continue
+            for channel_id, drafts in channels.items():
+                if not isinstance(drafts, dict):
+                    continue
+                for draft_type, draft in drafts.items():
+                    if not isinstance(draft, dict) or not draft.get("draft"):
+                        continue
+                    key = (account_id, channel_id, draft_type,
+                           draft.get("timestamp"), draft["draft"])
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    data_list.append((
+                        discord_api.epoch_ms_to_datetime(draft.get("timestamp")),
+                        draft["draft"],
+                        channel_id,
+                        account_id,
+                        "Channel message" if draft_type == "0" else f"Type {draft_type}",
+                        record.sequence,
+                        record.state,
+                        context.get_relative_path(record.source),
+                    ))
+
+    data_list.sort(key=lambda row: row[0] if isinstance(row[0], datetime) else _EPOCH_MIN)
+    logfunc(f"Discord Message Drafts: {len(data_list)} draft version(s) recovered.")
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def discordActivity(context):
+    data_headers = (
+        ("Timestamp", "datetime"), "Event", "Target ID", "Detail",
+        "Local Storage Key", "LevelDB Sequence", "Source File",
+    )
+
+    data_list = []
+    seen = set()
+    source_path = ""
+
+    def add(timestamp, event, target, detail, record):
+        key = (timestamp, event, target, detail)
+        if key in seen:
+            return
+        seen.add(key)
+        data_list.append((timestamp, event, target, detail, record.key,
+                          record.sequence, context.get_relative_path(record.source)))
+
+    for record in _records(context):
+        state = None
+        if record.key in ("FrecencyStore", "SelectedGuildStore", "RecentVoiceChannelStore",
+                          "QuickSwitcherStore", "SelectedChannelStore",
+                          "LAST_CLIENT_HEARTBEAT_SESSION"):
+            state = _load_state(record)
+        if state is None:
+            continue
+        source_path = source_path or record.source
+
+        if record.key == "FrecencyStore":
+            for usage in state.get("pendingUsages") or []:
+                if not isinstance(usage, dict):
+                    continue
+                add(discord_api.epoch_ms_to_datetime(usage.get("timestamp")),
+                    "Channel opened", str(usage.get("key") or ""), "", record)
+
+        elif record.key == "SelectedGuildStore":
+            for guild_id, when in (state.get("selectedGuildTimestampMillis") or {}).items():
+                add(discord_api.epoch_ms_to_datetime(when), "Server selected",
+                    str(guild_id), "", record)
+
+        elif record.key == "SelectedChannelStore":
+            connected = state.get("lastConnectedTime") if isinstance(state, dict) else None
+            if state.get("selectedVoiceChannelId"):
+                add(discord_api.epoch_ms_to_datetime(connected), "Voice channel connected",
+                    str(state["selectedVoiceChannelId"]), "", record)
+            for guild_id, channel_id in (state.get("selectedChannelIds") or {}).items():
+                add("", "Last channel for server", str(channel_id),
+                    f"server {guild_id}", record)
+
+        elif record.key == "RecentVoiceChannelStore":
+            for position, channel_id in enumerate(state.get("voiceChannelHistory") or [], 1):
+                add("", "Recent voice channel", str(channel_id),
+                    f"position {position}", record)
+            for position, channel_id in enumerate(state.get("textChannelHistory") or [], 1):
+                add("", "Recent text channel", str(channel_id),
+                    f"position {position}", record)
+
+        elif record.key == "QuickSwitcherStore":
+            for position, channel_id in enumerate(state.get("channelHistory") or [], 1):
+                add("", "Quick switcher history", str(channel_id),
+                    f"position {position}", record)
+
+        elif record.key == "LAST_CLIENT_HEARTBEAT_SESSION":
+            session = state if isinstance(state, dict) else {}
+            add(discord_api.epoch_ms_to_datetime(session.get("createdAtTimestamp")),
+                "Client session started", session.get("uuid", ""), "", record)
+            add(discord_api.epoch_ms_to_datetime(session.get("lastUsedTimestamp")),
+                "Client session last used", session.get("uuid", ""), "", record)
+
+    data_list.sort(key=lambda row: row[0] if isinstance(row[0], datetime) else _EPOCH_MIN,
+                   reverse=True)
+    logfunc(f"Discord Client Activity: {len(data_list)} event(s) recovered.")
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def discordLocalStorage(context):
+    data_headers = (
+        "Origin", "Key", "Value", "Value Length", "LevelDB Sequence",
+        "Record State", "Source File",
+    )
+
+    data_list = []
+    source_path = ""
+    for record in _records(context):
+        source_path = source_path or record.source
+        if record.key in _REDACTED_KEYS and record.value:
+            value = "[redacted: authentication token]"
+        else:
+            value = record.value
+            if len(value) > _VALUE_LIMIT:
+                value = f"{value[:_VALUE_LIMIT]}... [truncated]"
+        data_list.append((
+            record.origin,
+            record.key,
+            value,
+            len(record.value),
+            record.sequence,
+            record.state,
+            context.get_relative_path(record.source),
+        ))
+
+    logfunc(f"Discord Local Storage: {len(data_list)} record version(s).")
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/discordLocalStorage.py
+++ b/scripts/artifacts/discordLocalStorage.py
@@ -1,12 +1,14 @@
 __artifacts_v2__ = {
     "discordDrafts": {
         "name": "Discord Message Drafts",
-        "description": "Unsent message drafts held in Local Storage. Discord "
-                       "saves the draft box as the user types, and Local Storage "
-                       "is a LevelDB, so superseded versions of the key stay on "
-                       "disk. The result is a keystroke-level history of "
-                       "messages that were composed but never sent, each with "
-                       "its own timestamp and target channel.",
+        "description": "Message drafts held in Local Storage. Discord saves the "
+                       "draft box as text is typed, and Local Storage is a "
+                       "LevelDB, so superseded versions of the key stay on "
+                       "disk. The result is a keystroke-level history of text "
+                       "as it was composed, each version with its own "
+                       "timestamp and target channel. A row records what was in "
+                       "the compose box at that time; whether it was ever sent "
+                       "cannot be determined from this artifact alone.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
@@ -25,8 +27,10 @@ __artifacts_v2__ = {
                        "state Discord keeps between runs: channels opened and "
                        "when, servers selected, voice channels joined, quick "
                        "switcher history and client session heartbeats. This is "
-                       "usage evidence that exists independently of any message "
-                       "content.",
+                       "usage state that exists independently of any message "
+                       "content: it records when the client opened channels, "
+                       "selected servers and started sessions, whether or not "
+                       "any message from those channels was cached.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
@@ -44,8 +48,11 @@ __artifacts_v2__ = {
         "name": "Discord Local Storage",
         "description": "Raw Local Storage keys and values for the Discord "
                        "origins, including superseded and deleted versions "
-                       "recovered from the LevelDB table and log files. Use this "
-                       "when a store is not yet parsed into its own artifact.",
+                       "recovered from the LevelDB table and log files. Because "
+                       "LevelDB does not overwrite in place, a value the app "
+                       "has since changed or deleted can still be read here. "
+                       "Use this when a store is not yet parsed into its own "
+                       "artifact.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",

--- a/scripts/artifacts/discordLogs.py
+++ b/scripts/artifacts/discordLogs.py
@@ -1,19 +1,24 @@
 __artifacts_v2__ = {
     "discordNavigation": {
         "name": "Discord Channel Navigation",
-        "description": "Channels and servers the user moved to inside the "
-                       "client, taken from the renderer log the desktop app "
-                       "writes. Each routing entry names the server, the channel "
-                       "and, when the user jumped to a specific message, that "
-                       "message ID.",
+        "description": "Channels and servers the client routed to inside the "
+                       "application, taken from the renderer log the desktop "
+                       "app writes. Each entry records the destination the "
+                       "client navigated to at that time, naming the server, "
+                       "the channel and, where the route targeted one, a "
+                       "specific message ID. Timestamps are the device's local "
+                       "time, not UTC.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "Discord (Desktop)",
         "notes": "Renderer log timestamps are written in the device's local "
-                 "time with no offset recorded, so they are reported as local "
-                 "time and must be reconciled with the machine's time zone.",
+                 "time with no offset recorded, so they must be reconciled "
+                 "against the time zone reported by the Discord Account & "
+                 "Application artifact before being placed on a UTC timeline. "
+                 "The log rotates, so coverage reaches back only as far as the "
+                 "retained renderer_js logs.",
         "paths": (
             '*/discord*/logs/renderer_js*.log',
         ),
@@ -24,17 +29,20 @@ __artifacts_v2__ = {
         "name": "Discord Gateway Sessions",
         "description": "Connections the client made to the Discord real-time "
                        "gateway, from the renderer log. Shows when the app came "
-                       "online, which regional gateway it used and which session "
-                       "it resumed, which brackets the periods the account was "
-                       "actually connected.",
+                       "online, which regional gateway it used and which "
+                       "session it resumed, so the events bracket the intervals "
+                       "in which the client held a gateway connection. "
+                       "Timestamps are the device's local time, not UTC.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "Discord (Desktop)",
-        "notes": "Timestamps are device local time, as written by the client. "
-                 "The gateway hostname identifies the region Discord assigned "
-                 "to the connection.",
+        "notes": "Timestamps are device local time, as written by the client, "
+                 "and must be reconciled against the time zone reported by the "
+                 "Discord Account & Application artifact. The gateway hostname "
+                 "contains the region label Discord assigned to the "
+                 "connection.",
         "paths": (
             '*/discord*/logs/renderer_js*.log',
         ),

--- a/scripts/artifacts/discordLogs.py
+++ b/scripts/artifacts/discordLogs.py
@@ -1,0 +1,150 @@
+__artifacts_v2__ = {
+    "discordNavigation": {
+        "name": "Discord Channel Navigation",
+        "description": "Channels and servers the user moved to inside the "
+                       "client, taken from the renderer log the desktop app "
+                       "writes. Each routing entry names the server, the channel "
+                       "and, when the user jumped to a specific message, that "
+                       "message ID.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "Renderer log timestamps are written in the device's local "
+                 "time with no offset recorded, so they are reported as local "
+                 "time and must be reconciled with the machine's time zone.",
+        "paths": (
+            '*/discord*/logs/renderer_js*.log',
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "navigation",
+    },
+    "discordGatewaySessions": {
+        "name": "Discord Gateway Sessions",
+        "description": "Connections the client made to the Discord real-time "
+                       "gateway, from the renderer log. Shows when the app came "
+                       "online, which regional gateway it used and which session "
+                       "it resumed, which brackets the periods the account was "
+                       "actually connected.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "Timestamps are device local time, as written by the client. "
+                 "The gateway hostname identifies the region Discord assigned "
+                 "to the connection.",
+        "paths": (
+            '*/discord*/logs/renderer_js*.log',
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "plug",
+    },
+}
+
+import os
+import re
+from datetime import datetime
+
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_LINE_RE = re.compile(r"^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})\]\s+\[(\w+)\]\s+(.*)$")
+_ROUTE_RE = re.compile(
+    r"\[Routing/Utils\].*?Transitioning to /channels/(@me|\d+)/(\d+)(?:/(\d+))?")
+_GATEWAY_RE = re.compile(r"\[GatewaySocket\]\s+\[([A-Z ]+)\]\s*(.*)$")
+_SESSION_RE = re.compile(r"session ([0-9a-f]{16,})")
+_HOST_RE = re.compile(r"wss://([^/\s,]+)")
+_TIMING_RE = re.compile(r"in (\d+) ?ms|took (\d+)ms")
+
+
+def _parse_local_time(value):
+    try:
+        return datetime.strptime(value, "%Y-%m-%d %H:%M:%S.%f")
+    except ValueError:
+        return ""
+
+
+def _iter_log_lines(files_found):
+    seen = set()
+    for file_found in files_found:
+        file_found = str(file_found)
+        try:
+            real = os.path.realpath(file_found)
+        except OSError:
+            real = file_found
+        if real in seen:
+            continue
+        seen.add(real)
+        try:
+            with open(file_found, "r", encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    match = _LINE_RE.match(line.rstrip("\n"))
+                    if match:
+                        yield file_found, match.group(1), match.group(2), match.group(3)
+        except OSError as ex:
+            logfunc(f"Discord logs: could not read '{file_found}': {ex}")
+
+
+@artifact_processor
+def discordNavigation(context):
+    data_headers = (
+        ("Timestamp (Device Local Time)", "datetime"), "Destination",
+        "Server ID", "Channel ID", "Message ID", "Source File",
+    )
+
+    data_list = []
+    source_path = ""
+    for file_found, timestamp, _level, message in _iter_log_lines(
+            context.get_files_found()):
+        match = _ROUTE_RE.search(message)
+        if not match:
+            continue
+        source_path = source_path or file_found
+        guild = match.group(1)
+        data_list.append((
+            _parse_local_time(timestamp),
+            "Direct messages" if guild == "@me" else f"Server {guild}",
+            "" if guild == "@me" else guild,
+            match.group(2),
+            match.group(3) or "",
+            context.get_relative_path(file_found),
+        ))
+
+    data_list.sort(key=lambda row: row[0] if isinstance(row[0], datetime) else datetime.min)
+    logfunc(f"Discord Channel Navigation: {len(data_list)} navigation event(s).")
+    return data_headers, data_list, source_path
+
+
+@artifact_processor
+def discordGatewaySessions(context):
+    data_headers = (
+        ("Timestamp (Device Local Time)", "datetime"), "Event", "Gateway Host",
+        "Session ID", "Duration (ms)", "Detail", "Source File",
+    )
+
+    data_list = []
+    source_path = ""
+    for file_found, timestamp, _level, message in _iter_log_lines(
+            context.get_files_found()):
+        match = _GATEWAY_RE.search(message)
+        if not match:
+            continue
+        source_path = source_path or file_found
+        detail = match.group(2).strip()
+        host = _HOST_RE.search(detail)
+        session = _SESSION_RE.search(detail)
+        timing = _TIMING_RE.search(detail)
+        data_list.append((
+            _parse_local_time(timestamp),
+            match.group(1).strip().title(),
+            host.group(1) if host else "",
+            session.group(1) if session else "",
+            (timing.group(1) or timing.group(2)) if timing else "",
+            detail,
+            context.get_relative_path(file_found),
+        ))
+
+    data_list.sort(key=lambda row: row[0] if isinstance(row[0], datetime) else datetime.min)
+    logfunc(f"Discord Gateway Sessions: {len(data_list)} gateway event(s).")
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/discordMedia.py
+++ b/scripts/artifacts/discordMedia.py
@@ -1,0 +1,116 @@
+__artifacts_v2__ = {
+    "discordRecoveredMedia": {
+        "name": "Discord Recovered Media",
+        "description": "Every Discord image, video, avatar, emoji, sticker and "
+                       "server icon still held in the application cache, "
+                       "extracted and embedded in the report. Attachment URLs "
+                       "carry the channel ID and an attachment snowflake, so a "
+                       "cached file can be tied to its channel and dated even "
+                       "when the message that carried it is long gone from the "
+                       "cache.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "The 'Message Recovered' column separates media that still has "
+                 "a matching cached message from orphaned media, which is the "
+                 "case that matters when messages have been deleted. Discord "
+                 "serves resized WebP copies to the client, so recovered bytes "
+                 "are often a transcode rather than the original upload.",
+        "paths": (
+            '*/discord*/Cache/Cache_Data/*_0',
+            '*/discord*/Service Worker/CacheStorage/*/*/*_0',
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "image",
+    },
+}
+
+import os
+from datetime import datetime, timezone
+
+from scripts.chromium import discord_api
+from scripts.chromium.simple_cache import read_entry
+from scripts.ilapfuncs import artifact_processor, check_in_embedded_media, logfunc
+
+
+def _channel_label(scan, channel_id):
+    channel = scan.channels.get(channel_id) or {}
+    if channel.get("name"):
+        return f"#{channel['name']}"
+    return channel.get("recipients") or channel_id or ""
+
+
+@artifact_processor
+def discordRecoveredMedia(context):
+    data_headers = (
+        ("Created", "datetime"), "Kind", ("Media", "media"), "Filename",
+        "Channel", "Message Recovered", "Content Type", "Size (bytes)",
+        "Owner ID", "Related ID", ("Cached", "datetime"), "URL",
+        "Source Cache File",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    scan = discord_api.scan_cache(files_found, log=logfunc)
+    if not scan.media:
+        return data_headers, [], ""
+
+    # Attachment ids that still have a cached message behind them.
+    known_attachments = {}
+    for message_id, wrapper in scan.messages.items():
+        for attachment in wrapper["message"].get("attachments") or []:
+            if isinstance(attachment, dict) and attachment.get("id"):
+                known_attachments[str(attachment["id"])] = message_id
+
+    data_list = []
+    for path, media in sorted(scan.media.items(), key=lambda item: item[1]["url"]):
+        entry = read_entry(path)
+        if entry is None:
+            continue
+        body = entry.decoded_body()
+        if not body:
+            continue
+
+        content_type = (media.get("content_type") or "").split(";")[0].strip()
+        filename = discord_api.attachment_filename(media["url"])
+        # Prefer the served type for images and video (Discord transcodes to
+        # WebP), otherwise keep the extension the file was uploaded with.
+        if content_type.startswith(("image/", "video/", "audio/")):
+            extension = content_type.split("/")[-1]
+        else:
+            extension = os.path.splitext(filename)[1].lstrip(".")
+        created = discord_api.snowflake_to_datetime(media["owner_id"]) \
+            if media["kind"] in ("Attachment", "Emoji", "Sticker") else ""
+        reference = check_in_embedded_media(
+            path, body, filename or f"{media['owner_id'] or 'media'}.{extension or 'bin'}",
+            force_type=content_type or None, force_extension=extension or None)
+        if not reference:
+            continue
+
+        linked = ""
+        if media["kind"] == "Attachment":
+            linked = "Yes" if media["owner_id"] in known_attachments else "No"
+
+        data_list.append((
+            created,
+            media["kind"],
+            reference,
+            filename,
+            _channel_label(scan, media["related_id"]) if media["related_id"] else "",
+            linked,
+            content_type,
+            len(body),
+            media["owner_id"],
+            media["related_id"],
+            media["cached"],
+            media["url"],
+            context.get_relative_path(path),
+        ))
+
+    data_list.sort(key=lambda row: (row[1], row[0] if isinstance(row[0], datetime)
+                                    else datetime.min.replace(tzinfo=timezone.utc)))
+    orphans = {row[8] for row in data_list if row[5] == "No"}
+    logfunc(f"Discord Recovered Media: {len(data_list)} cached file(s) recovered, "
+            f"including {len(orphans)} attachment(s) with no surviving cached message.")
+    return data_headers, data_list, "\n".join(sorted(scan.media)[:50])

--- a/scripts/artifacts/discordMedia.py
+++ b/scripts/artifacts/discordMedia.py
@@ -6,18 +6,23 @@ __artifacts_v2__ = {
                        "extracted and embedded in the report. Attachment URLs "
                        "carry the channel ID and an attachment snowflake, so a "
                        "cached file can be tied to its channel and dated even "
-                       "when the message that carried it is long gone from the "
-                       "cache.",
+                       "when the message that carried it is long gone. The "
+                       "'Message Recovered' column flags files whose "
+                       "attachment ID matches no message recovered from this "
+                       "cache. The cache evicts over time, so the absence of a "
+                       "file here does not indicate it was never present.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "Discord (Desktop)",
-        "notes": "The 'Message Recovered' column separates media that still has "
-                 "a matching cached message from orphaned media, which is the "
-                 "case that matters when messages have been deleted. Discord "
-                 "serves resized WebP copies to the client, so recovered bytes "
-                 "are often a transcode rather than the original upload.",
+        "notes": "Discord serves resized WebP copies to the client, so "
+                 "recovered bytes are often a transcode rather than the "
+                 "original upload and will not necessarily hash to the file as "
+                 "it was uploaded. One "
+                 "row per cached file: the same image appears more than once "
+                 "where the client fetched it at several sizes, though "
+                 "identical bytes are stored only once.",
         "paths": (
             '*/discord*/Cache/Cache_Data/*_0',
             '*/discord*/Service Worker/CacheStorage/*/*/*_0',

--- a/scripts/artifacts/discordMessages.py
+++ b/scripts/artifacts/discordMessages.py
@@ -4,18 +4,23 @@ __artifacts_v2__ = {
         "description": "Chat messages recovered from the Discord Desktop HTTP "
                        "cache. Discord renders its UI from REST API responses, "
                        "and those JSON responses stay in the Chromium cache "
-                       "after the app closes, so messages survive here even "
-                       "when they were later deleted server-side. Where the "
-                       "attachment image is also still cached it is recovered "
-                       "and shown against its message.",
+                       "after the app closes. A cached response is a copy of "
+                       "what the API returned to this client at the moment it "
+                       "was stored, and it is not updated if the message is "
+                       "later edited or deleted server-side. The cache evicts "
+                       "over time, so the absence of a message here does not "
+                       "indicate it was never sent. Where the attachment image "
+                       "is also still cached it is recovered and shown against "
+                       "its message.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "Discord (Desktop)",
         "notes": "Parses cached responses to /api/v*/channels/<id>/messages and "
-                 "the message search endpoints. Cached copies are point-in-time: "
-                 "the most recently cached version of each message is reported. "
+                 "the message search endpoints. Each cached copy is a "
+                 "point-in-time snapshot and the most recent one is reported, so "
+                 "an edit made after the last cache write is not reflected here. "
                  "Direction is resolved against the signed-in account id taken "
                  "from the Sentry scope and Local Storage.",
         "paths": (
@@ -44,9 +49,14 @@ __artifacts_v2__ = {
         "description": "Files shared in Discord conversations, taken from the "
                        "attachment metadata inside cached message responses and "
                        "linked to the cached copy of the file itself where one "
-                       "survives. The attachment ID is a snowflake, so the "
-                       "upload time is recoverable even when only the URL "
-                       "remains.",
+                       "survives. Each row records an attachment the API "
+                       "reported on a message: its filename, declared size and "
+                       "type, the account that posted the message and the "
+                       "channel it appeared in. The attachment ID is a "
+                       "snowflake, so the upload time is recoverable from the "
+                       "URL alone even when the file itself is gone. The cache "
+                       "evicts over time, so the absence of a file here does "
+                       "not indicate it was never shared.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",

--- a/scripts/artifacts/discordMessages.py
+++ b/scripts/artifacts/discordMessages.py
@@ -1,0 +1,294 @@
+__artifacts_v2__ = {
+    "discordMessages": {
+        "name": "Discord Messages",
+        "description": "Chat messages recovered from the Discord Desktop HTTP "
+                       "cache. Discord renders its UI from REST API responses, "
+                       "and those JSON responses stay in the Chromium cache "
+                       "after the app closes, so messages survive here even "
+                       "when they were later deleted server-side. Where the "
+                       "attachment image is also still cached it is recovered "
+                       "and shown against its message.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "Parses cached responses to /api/v*/channels/<id>/messages and "
+                 "the message search endpoints. Cached copies are point-in-time: "
+                 "the most recently cached version of each message is reported. "
+                 "Direction is resolved against the signed-in account id taken "
+                 "from the Sentry scope and Local Storage.",
+        "paths": (
+            '*/discord*/Cache/Cache_Data/*_0',
+            '*/discord*/Service Worker/CacheStorage/*/*/*_0',
+            '*/discord*/sentry/scope_v3.json',
+            '*/discord*/Local Storage/leveldb/*',
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "message-circle",
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Channel ID",
+                "conversationLabelColumn": "Channel",
+                "textColumn": "Message",
+                "timeColumn": "Timestamp",
+                "directionColumn": "Direction",
+                "directionSentValue": "Sent",
+                "senderColumn": "Sender",
+                "mediaColumn": "Attachments",
+            }
+        },
+    },
+    "discordAttachments": {
+        "name": "Discord Attachments",
+        "description": "Files shared in Discord conversations, taken from the "
+                       "attachment metadata inside cached message responses and "
+                       "linked to the cached copy of the file itself where one "
+                       "survives. The attachment ID is a snowflake, so the "
+                       "upload time is recoverable even when only the URL "
+                       "remains.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "Cached copies are frequently the WebP variant Discord serves "
+                 "to the client rather than the original upload, so the "
+                 "recovered bytes can differ from the file the sender chose. "
+                 "The reported size is the size declared by the API.",
+        "paths": (
+            '*/discord*/Cache/Cache_Data/*_0',
+            '*/discord*/Service Worker/CacheStorage/*/*/*_0',
+            '*/discord*/sentry/scope_v3.json',
+            '*/discord*/Local Storage/leveldb/*',
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "paperclip",
+    },
+}
+
+import os
+from datetime import datetime, timezone
+
+from scripts.chromium import discord_api
+from scripts.chromium.simple_cache import read_entry
+from scripts.ilapfuncs import artifact_processor, check_in_embedded_media, logfunc
+
+# Discord caps a message at ten attachments, so this never truncates a message.
+_MAX_MEDIA_PER_MESSAGE = 10
+
+
+def _channel_label(scan, channel_id):
+    channel = scan.channels.get(channel_id) or {}
+    if channel.get("name"):
+        return f"#{channel['name']}"
+    if channel.get("recipients"):
+        return channel["recipients"]
+    return channel_id or ""
+
+
+def _best_cached_media(scan):
+    """Map attachment id -> the largest cached copy of that attachment."""
+    best = {}
+    for path, media in scan.media.items():
+        if media["kind"] != "Attachment" or not media["owner_id"]:
+            continue
+        current = best.get(media["owner_id"])
+        if current is None or media["size"] > current[1]["size"]:
+            best[media["owner_id"]] = (path, media)
+    return best
+
+
+def _recover_media(path, media, filename):
+    """Check the cached bytes in as a media item and return its reference id."""
+    entry = read_entry(path)
+    if entry is None:
+        return None
+    body = entry.decoded_body()
+    if not body:
+        return None
+    extension = os.path.splitext(filename)[1].lstrip(".")
+    content_type = media.get("content_type", "").split(";")[0].strip()
+    # Discord transcodes to WebP on delivery; trust the served type over the name.
+    if content_type.startswith("image/") or content_type.startswith("video/"):
+        extension = content_type.split("/")[-1]
+    return check_in_embedded_media(
+        path, body, filename or f"{media['owner_id']}.{extension or 'bin'}",
+        force_type=content_type or None,
+        force_extension=extension or None,
+        force_creation_date=_epoch(media.get("cached")),
+    )
+
+
+def _epoch(value):
+    if isinstance(value, datetime):
+        return int(value.timestamp())
+    return None
+
+
+def _describe_embeds(message):
+    parts = []
+    for embed in message.get("embeds") or []:
+        if not isinstance(embed, dict):
+            continue
+        label = embed.get("title") or embed.get("description") or embed.get("type") or ""
+        url = embed.get("url") or ""
+        parts.append(f"{label} {url}".strip() if label or url else "embed")
+    return "\n".join(parts)
+
+
+def _describe_stickers(message):
+    return ", ".join(
+        sticker.get("name", "") for sticker in (message.get("sticker_items") or [])
+        if isinstance(sticker, dict))
+
+
+def _reply_reference(message):
+    reference = message.get("message_reference")
+    if not isinstance(reference, dict):
+        return ""
+    referenced = message.get("referenced_message")
+    if isinstance(referenced, dict):
+        author = discord_api.user_display(referenced.get("author"))
+        content = (referenced.get("content") or "").replace("\n", " ")
+        if author or content:
+            return f"{author}: {content[:120]}"
+    return f"message {reference.get('message_id', '')}"
+
+
+@artifact_processor
+def discordMessages(context):
+    data_headers = (
+        ("Timestamp", "datetime"), "Direction", "Sender", "Channel", "Message",
+        ("Attachments", "media"), "Attachment Names", ("Edited", "datetime"),
+        "Reply To", "Mentions", "Embeds", "Stickers", "Message Type", "Pinned",
+        "Sender ID", "Channel ID", "Message ID", ("Cached", "datetime"),
+        "Source Cache File",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    scan = discord_api.scan_cache(files_found, log=logfunc)
+    if not scan.messages:
+        return data_headers, [], ""
+
+    account = discord_api.find_local_account(files_found)
+    local_ids = account["ids"] or ({account["id"]} if account["id"] else set())
+    cached_media = _best_cached_media(scan)
+
+    data_list = []
+    for message_id, wrapper in scan.messages.items():
+        message = wrapper["message"]
+        author = message.get("author") or {}
+        author_id = str(author.get("id") or "")
+        sent = discord_api.iso_to_datetime(message.get("timestamp")) \
+            or discord_api.snowflake_to_datetime(message_id)
+
+        media_refs = []
+        names = []
+        for attachment in (message.get("attachments") or [])[:_MAX_MEDIA_PER_MESSAGE]:
+            if not isinstance(attachment, dict):
+                continue
+            names.append(attachment.get("filename", ""))
+            found = cached_media.get(str(attachment.get("id")))
+            if found:
+                reference = _recover_media(found[0], found[1],
+                                           attachment.get("filename", ""))
+                if reference:
+                    media_refs.append(reference)
+
+        data_list.append((
+            sent,
+            "Sent" if author_id and author_id in local_ids else "Received",
+            discord_api.user_display(author),
+            _channel_label(scan, str(message.get("channel_id") or "")),
+            message.get("content") or "",
+            media_refs,
+            ", ".join(n for n in names if n),
+            discord_api.iso_to_datetime(message.get("edited_timestamp")),
+            _reply_reference(message),
+            ", ".join(discord_api.user_display(m) for m in (message.get("mentions") or [])
+                      if isinstance(m, dict)),
+            _describe_embeds(message),
+            _describe_stickers(message),
+            discord_api.message_type_name(message.get("type")),
+            "Yes" if message.get("pinned") else "",
+            author_id,
+            str(message.get("channel_id") or ""),
+            message_id,
+            wrapper["cached"],
+            context.get_relative_path(wrapper["source"]),
+        ))
+
+    data_list.sort(key=lambda row: (row[15], row[0] if isinstance(row[0], datetime)
+                                    else datetime.min.replace(tzinfo=timezone.utc)))
+    logfunc(f"Discord Messages: {len(data_list)} message(s) from "
+            f"{len(scan.channels)} channel(s) across {scan.entry_count} cache entries.")
+    source = "\n".join(sorted({wrapper["source"] for wrapper in scan.messages.values()})[:50])
+    return data_headers, data_list, source
+
+
+@artifact_processor
+def discordAttachments(context):
+    data_headers = (
+        ("Uploaded", "datetime"), "Sender", "Channel", "Filename",
+        ("Recovered File", "media"), "Declared Size (bytes)", "Content Type",
+        "Dimensions", "Cached Copy", ("Message Sent", "datetime"), "Message",
+        "Sender ID", "Channel ID", "Attachment ID", "Message ID", "URL",
+        "Source Cache File",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    scan = discord_api.scan_cache(files_found, log=logfunc)
+    if not scan.messages:
+        return data_headers, [], ""
+
+    cached_media = _best_cached_media(scan)
+
+    data_list = []
+    for message_id, wrapper in scan.messages.items():
+        message = wrapper["message"]
+        attachments = message.get("attachments") or []
+        if not attachments:
+            continue
+        author = message.get("author") or {}
+        channel_id = str(message.get("channel_id") or "")
+        sent = discord_api.iso_to_datetime(message.get("timestamp")) \
+            or discord_api.snowflake_to_datetime(message_id)
+
+        for attachment in attachments:
+            if not isinstance(attachment, dict):
+                continue
+            attachment_id = str(attachment.get("id") or "")
+            filename = attachment.get("filename", "")
+            found = cached_media.get(attachment_id)
+            reference = None
+            if found:
+                reference = _recover_media(found[0], found[1], filename)
+            width, height = attachment.get("width"), attachment.get("height")
+            data_list.append((
+                discord_api.snowflake_to_datetime(attachment_id),
+                discord_api.user_display(author),
+                _channel_label(scan, channel_id),
+                filename,
+                reference,
+                attachment.get("size", ""),
+                attachment.get("content_type", ""),
+                f"{width}x{height}" if width and height else "",
+                "Yes" if reference else "No",
+                sent,
+                (message.get("content") or "")[:200],
+                str(author.get("id") or ""),
+                channel_id,
+                attachment_id,
+                message_id,
+                attachment.get("url", ""),
+                context.get_relative_path(found[0]) if found else "",
+            ))
+
+    data_list.sort(key=lambda row: row[0] if isinstance(row[0], datetime)
+                   else datetime.min.replace(tzinfo=timezone.utc))
+    recovered = sum(1 for row in data_list if row[4])
+    logfunc(f"Discord Attachments: {len(data_list)} attachment(s), "
+            f"{recovered} recovered from the cache.")
+    source = "\n".join(sorted({wrapper["source"] for wrapper in scan.messages.values()})[:50])
+    return data_headers, data_list, source

--- a/scripts/artifacts/discordSearches.py
+++ b/scripts/artifacts/discordSearches.py
@@ -1,0 +1,133 @@
+__artifacts_v2__ = {
+    "discordSearches": {
+        "name": "Discord Searches",
+        "description": "Searches the user ran inside Discord. The search term "
+                       "is part of the request URL, so it survives in the cache "
+                       "key itself, and the cached response shows how many "
+                       "results came back. Covers in-channel and server-wide "
+                       "message searches as well as GIF picker searches.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "Message search hits are also folded into the Discord Messages "
+                 "artifact, which means a searched-for message can be recovered "
+                 "even when the channel's own message responses are gone.",
+        "paths": (
+            '*/discord*/Cache/Cache_Data/*_0',
+            '*/discord*/Service Worker/CacheStorage/*/*/*_0',
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "search",
+    },
+    "discordReactions": {
+        "name": "Discord Reactions",
+        "description": "Users who reacted to a message with a given emoji, from "
+                       "cached reaction listings. Each row places a named "
+                       "account on a specific message in a specific channel.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "none",
+        "category": "Discord (Desktop)",
+        "notes": "Discord only requests this endpoint when the user hovers or "
+                 "opens the reaction list, so coverage is limited to messages "
+                 "whose reactions were actually inspected.",
+        "paths": (
+            '*/discord*/Cache/Cache_Data/*_0',
+            '*/discord*/Service Worker/CacheStorage/*/*/*_0',
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "smile",
+    },
+}
+
+from datetime import datetime, timezone
+
+from scripts.chromium import discord_api
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_EPOCH_MIN = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _channel_label(scan, channel_id):
+    channel = scan.channels.get(channel_id) or {}
+    if channel.get("name"):
+        return f"#{channel['name']}"
+    return channel.get("recipients") or channel_id or ""
+
+
+@artifact_processor
+def discordSearches(context):
+    data_headers = (
+        ("Requested", "datetime"), "Search Type", "Search Terms", "Filters",
+        "Scope", "Total Results", "Hits In Response", ("Cached", "datetime"),
+        "Request URL", "Source Cache File",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    scan = discord_api.scan_cache(files_found, log=logfunc)
+    if not scan.searches:
+        return data_headers, [], ""
+
+    data_list = []
+    for search in scan.searches:
+        filters = search.get("filters", "")
+        if not search["terms"] and not filters:
+            continue
+        data_list.append((
+            search["requested"],
+            search["type"],
+            search["terms"],
+            filters,
+            search["scope"],
+            search["results"] if search["results"] is not None else "",
+            len(search["hits"]) or "",
+            search["cached"],
+            search["url"],
+            context.get_relative_path(search["source"]),
+        ))
+
+    data_list.sort(key=lambda row: row[0] if isinstance(row[0], datetime) else _EPOCH_MIN)
+    logfunc(f"Discord Searches: {len(data_list)} search(es) recovered.")
+    return data_headers, data_list, "\n".join(
+        sorted({s["source"] for s in scan.searches})[:50])
+
+
+@artifact_processor
+def discordReactions(context):
+    data_headers = (
+        ("Message Sent", "datetime"), "Emoji", "Reacting User", "Channel",
+        "Message", "User ID", "Message ID", "Channel ID",
+        ("Cached", "datetime"), "Source Cache File",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    scan = discord_api.scan_cache(files_found, log=logfunc)
+    if not scan.reactions:
+        return data_headers, [], ""
+
+    data_list = []
+    for reaction in scan.reactions:
+        message_wrapper = scan.messages.get(reaction["message_id"])
+        message_text = ""
+        if message_wrapper:
+            message_text = (message_wrapper["message"].get("content") or "")[:200]
+        data_list.append((
+            discord_api.snowflake_to_datetime(reaction["message_id"]),
+            reaction["emoji"],
+            discord_api.user_display(reaction["user"]),
+            _channel_label(scan, reaction["channel_id"]),
+            message_text,
+            str((reaction["user"] or {}).get("id") or ""),
+            reaction["message_id"],
+            reaction["channel_id"],
+            reaction["cached"],
+            context.get_relative_path(reaction["source"]),
+        ))
+
+    data_list.sort(key=lambda row: row[0] if isinstance(row[0], datetime) else _EPOCH_MIN)
+    logfunc(f"Discord Reactions: {len(data_list)} reaction(s) recovered.")
+    return data_headers, data_list, "\n".join(
+        sorted({r["source"] for r in scan.reactions})[:50])

--- a/scripts/artifacts/discordSearches.py
+++ b/scripts/artifacts/discordSearches.py
@@ -1,11 +1,13 @@
 __artifacts_v2__ = {
     "discordSearches": {
         "name": "Discord Searches",
-        "description": "Searches the user ran inside Discord. The search term "
-                       "is part of the request URL, so it survives in the cache "
-                       "key itself, and the cached response shows how many "
-                       "results came back. Covers in-channel and server-wide "
-                       "message searches as well as GIF picker searches.",
+        "description": "Searches issued from the Discord client. The search "
+                       "term is part of the request URL, so it survives in the "
+                       "cache key itself, and the cached response shows how "
+                       "many results came back. The terms are those submitted "
+                       "to Discord's own search from this installation. Covers "
+                       "in-channel and server-wide message searches as well as "
+                       "GIF picker searches.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
@@ -13,7 +15,10 @@ __artifacts_v2__ = {
         "category": "Discord (Desktop)",
         "notes": "Message search hits are also folded into the Discord Messages "
                  "artifact, which means a searched-for message can be recovered "
-                 "even when the channel's own message responses are gone.",
+                 "even when the channel's own message responses are gone. "
+                 "Discord can search on filters alone, with no typed term; "
+                 "those appear with an empty Search Terms and the filter shown "
+                 "in the Filters column.",
         "paths": (
             '*/discord*/Cache/Cache_Data/*_0',
             '*/discord*/Service Worker/CacheStorage/*/*/*_0',
@@ -25,15 +30,22 @@ __artifacts_v2__ = {
         "name": "Discord Reactions",
         "description": "Users who reacted to a message with a given emoji, from "
                        "cached reaction listings. Each row places a named "
-                       "account on a specific message in a specific channel.",
+                       "account on a specific message in a specific channel, so "
+                       "it records which accounts Discord reported as having "
+                       "reacted to that message. Discord only requests this "
+                       "listing when a reaction list is hovered or opened, so "
+                       "coverage is limited to messages whose reactions were "
+                       "inspected in the client.",
         "author": "@AlexisBrignoni",
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
         "requirements": "none",
         "category": "Discord (Desktop)",
-        "notes": "Discord only requests this endpoint when the user hovers or "
-                 "opens the reaction list, so coverage is limited to messages "
-                 "whose reactions were actually inspected.",
+        "notes": "The listing is capped by the limit Discord requested, so a "
+                 "heavily reacted message may show only the first few accounts. "
+                 "Message Sent is derived from the message snowflake in the "
+                 "request URL and is available even when the message itself was "
+                 "not recovered.",
         "paths": (
             '*/discord*/Cache/Cache_Data/*_0',
             '*/discord*/Service Worker/CacheStorage/*/*/*_0',

--- a/scripts/chromium/__init__.py
+++ b/scripts/chromium/__init__.py
@@ -1,0 +1,7 @@
+"""Readers for the on-disk formats used by Chromium-based desktop apps.
+
+Electron applications (Discord, Slack, Signal Desktop, Wire, ...) store their
+web-layer data in the same formats a Chrome profile uses. The modules here
+parse those container formats so that per-application artifacts only have to
+deal with the application's own data.
+"""

--- a/scripts/chromium/discord_api.py
+++ b/scripts/chromium/discord_api.py
@@ -1,0 +1,534 @@
+"""Shared parsing of Discord Desktop data held in Chromium containers.
+
+Discord Desktop is an Electron front end for the same REST API the web client
+uses, so the JSON the app rendered is still sitting in the Chromium HTTP cache
+long after it left the screen. This module walks that cache once and hands the
+individual artifacts a decoded view of it: messages, users, channels,
+attachments, reactions, searches and the raw request index.
+
+A single scan is memoised per file list because several artifacts share it,
+and message bodies are only decompressed for endpoints that are known to carry
+JSON worth keeping.
+"""
+
+import hashlib
+import json
+import re
+from datetime import datetime, timedelta, timezone
+from urllib.parse import parse_qs, unquote, urlparse
+
+from scripts.chromium.simple_cache import base_time_to_datetime, iter_entries
+
+# Snowflake IDs count milliseconds from 2015-01-01, Discord's first second.
+SNOWFLAKE_EPOCH_MS = 1420070400000
+_SNOWFLAKE_EPOCH = datetime(2015, 1, 1, tzinfo=timezone.utc)
+
+_API_RE = re.compile(r"https://(?:discord|discordapp)\.com/api/v(\d+)/(.+)$")
+_MESSAGES_RE = re.compile(r"^channels/(\d+)/messages(?:\?|$)")
+_MESSAGE_SEARCH_RE = re.compile(r"^(channels|guilds)/(\d+)/messages/search")
+_REACTIONS_RE = re.compile(r"^channels/(\d+)/messages/(\d+)/reactions/([^?]+)")
+_PROFILE_RE = re.compile(r"^users/(\d+)/profile")
+_CHANNEL_RE = re.compile(r"^channels/(\d+)(?:\?|$)")
+_GUILD_PROFILE_RE = re.compile(r"^guilds/(\d+)/(?:profile|basic)")
+_INVITE_RE = re.compile(r"^invites/([^/?]+)")
+_GIF_SEARCH_RE = re.compile(r"^gifs/(search|trending)")
+_NOTE_RE = re.compile(r"^users/@me/notes/(\d+)")
+
+# Message-search parameters that describe what was looked for, as opposed to
+# pagination and sort options.
+_SEARCH_FILTER_PARAMS = {
+    "author_id", "channel_id", "has", "mentions", "mention_everyone",
+    "pinned", "link_hostname", "attachment_filename", "attachment_extension",
+    "embed_provider", "embed_type",
+}
+
+_ATTACHMENT_RE = re.compile(
+    r"https://(?:media\.discordapp\.net|cdn\.discordapp\.com)/attachments/"
+    r"(\d+)/(\d+)/([^?]*)")
+_AVATAR_RE = re.compile(r"https://cdn\.discordapp\.com/avatars/(\d+)/([^?/]+)")
+_GUILD_AVATAR_RE = re.compile(
+    r"https://cdn\.discordapp\.com/guilds/(\d+)/users/(\d+)/avatars/([^?/]+)")
+_EMOJI_RE = re.compile(r"https://cdn\.discordapp\.com/emojis/(\d+)")
+_STICKER_RE = re.compile(r"https://media\.discordapp\.net/stickers/(\d+)"
+                         r"|https://cdn\.discordapp\.com/stickers/(\d+)")
+_ICON_RE = re.compile(r"https://cdn\.discordapp\.com/icons/(\d+)/([^?/]+)")
+_BANNER_RE = re.compile(r"https://cdn\.discordapp\.com/banners/(\d+)/([^?/]+)")
+_EXTERNAL_RE = re.compile(r"https://images-ext-\d\.discordapp\.net/external/[^/]+/(.+)$")
+
+# Versioned SPA bundle assets: high volume, no investigative value.
+_STATIC_ASSET_RE = re.compile(
+    r"https://(?:discord|discordapp)\.com/assets/[^?]+\.(?:js|css|woff2?|map|svg|ico)")
+
+_MESSAGE_TYPES = {
+    0: "Default", 1: "Recipient Add", 2: "Recipient Remove", 3: "Call",
+    4: "Channel Name Change", 5: "Channel Icon Change", 6: "Channel Pinned Message",
+    7: "User Join", 8: "Guild Boost", 9: "Guild Boost Tier 1",
+    10: "Guild Boost Tier 2", 11: "Guild Boost Tier 3", 12: "Channel Follow Add",
+    14: "Guild Discovery Disqualified", 15: "Guild Discovery Requalified",
+    18: "Thread Created", 19: "Reply", 20: "Chat Input Command",
+    21: "Thread Starter Message", 22: "Guild Invite Reminder",
+    23: "Context Menu Command", 24: "Auto Moderation Action",
+    25: "Role Subscription Purchase", 26: "Interaction Premium Upsell",
+    27: "Stage Start", 28: "Stage End", 29: "Stage Speaker",
+    31: "Stage Topic", 32: "Guild Application Premium Subscription",
+    36: "Guild Incident Alert Mode Enabled", 37: "Guild Incident Alert Mode Disabled",
+    38: "Guild Incident Report Raid", 39: "Guild Incident Report False Alarm",
+    46: "Poll Result", 47: "Changelog",
+}
+
+_CHANNEL_TYPES = {
+    0: "Guild Text", 1: "Direct Message", 2: "Guild Voice", 3: "Group DM",
+    4: "Guild Category", 5: "Guild Announcement", 10: "Announcement Thread",
+    11: "Public Thread", 12: "Private Thread", 13: "Guild Stage Voice",
+    14: "Guild Directory", 15: "Guild Forum", 16: "Guild Media",
+}
+
+
+def snowflake_to_datetime(snowflake):
+    """Convert a Discord snowflake ID to its embedded creation time (UTC)."""
+    try:
+        value = int(snowflake)
+    except (TypeError, ValueError):
+        return ""
+    if value <= 0:
+        return ""
+    try:
+        return _SNOWFLAKE_EPOCH + timedelta(milliseconds=value >> 22)
+    except (OverflowError, ValueError):
+        return ""
+
+
+def iso_to_datetime(value):
+    """Convert a Discord ISO-8601 timestamp to an aware UTC datetime."""
+    if not value or not isinstance(value, str):
+        return ""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return ""
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def epoch_ms_to_datetime(value):
+    """Convert a JavaScript millisecond timestamp to an aware UTC datetime."""
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return ""
+    if value <= 0:
+        return ""
+    try:
+        return datetime.fromtimestamp(value / 1000, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return ""
+
+
+def message_type_name(value):
+    return _MESSAGE_TYPES.get(value, f"Type {value}" if value is not None else "")
+
+
+def channel_type_name(value):
+    return _CHANNEL_TYPES.get(value, f"Type {value}" if value is not None else "")
+
+
+def user_display(user):
+    """Best available human-readable name for a Discord user object."""
+    if not isinstance(user, dict):
+        return ""
+    name = user.get("global_name") or user.get("username") or ""
+    handle = user.get("username") or ""
+    if name and handle and name != handle:
+        return f"{name} ({handle})"
+    return name or handle or user.get("id", "")
+
+
+def media_kind(url):
+    """Classify a Discord CDN URL. Returns (kind, owner id, related id)."""
+    match = _ATTACHMENT_RE.search(url)
+    if match:
+        return "Attachment", match.group(2), match.group(1)
+    match = _GUILD_AVATAR_RE.search(url)
+    if match:
+        return "Guild Avatar", match.group(2), match.group(1)
+    match = _AVATAR_RE.search(url)
+    if match:
+        return "Avatar", match.group(1), ""
+    match = _EMOJI_RE.search(url)
+    if match:
+        return "Emoji", match.group(1), ""
+    match = _STICKER_RE.search(url)
+    if match:
+        return "Sticker", match.group(1) or match.group(2), ""
+    match = _ICON_RE.search(url)
+    if match:
+        return "Guild Icon", match.group(1), ""
+    match = _BANNER_RE.search(url)
+    if match:
+        return "Banner", match.group(1), ""
+    match = _EXTERNAL_RE.search(url)
+    if match:
+        return "External Image", "", ""
+    return "", "", ""
+
+
+def attachment_filename(url):
+    match = _ATTACHMENT_RE.search(url)
+    return unquote(match.group(3)) if match else ""
+
+
+class DiscordCacheScan:
+    """Everything the Discord artifacts need from one pass over the cache."""
+
+    def __init__(self):
+        self.records = []          # lightweight row per cached response
+        self.messages = {}         # message id -> {"message", "source", "cached"}
+        self.profiles = {}         # user id -> {"profile", "source"}
+        self.users = {}            # user id -> merged user object + provenance
+        self.channels = {}         # channel id -> merged channel object
+        self.guilds = {}           # guild id -> merged guild object
+        self.reactions = []
+        self.searches = []
+        self.notes = []
+        self.invites = []
+        self.media = {}            # cache path -> media descriptor
+        self.entry_count = 0
+        self.source_paths = set()
+
+    # -- population helpers ------------------------------------------------ #
+
+    def _note_user(self, user, seen_in, when):
+        if not isinstance(user, dict) or not user.get("id"):
+            return
+        uid = user["id"]
+        record = self.users.setdefault(uid, {
+            "id": uid, "username": "", "global_name": "", "discriminator": "",
+            "bot": False, "avatar": "", "seen_in": set(), "first_seen": None,
+            "last_seen": None,
+        })
+        for field in ("username", "global_name", "discriminator", "avatar"):
+            if user.get(field) and not record[field]:
+                record[field] = user[field]
+        if user.get("bot"):
+            record["bot"] = True
+        record["seen_in"].add(seen_in)
+        if isinstance(when, datetime):
+            if record["first_seen"] is None or when < record["first_seen"]:
+                record["first_seen"] = when
+            if record["last_seen"] is None or when > record["last_seen"]:
+                record["last_seen"] = when
+
+    def _note_channel(self, channel, source=""):
+        if not isinstance(channel, dict) or not channel.get("id"):
+            return
+        cid = channel["id"]
+        record = self.channels.setdefault(cid, {
+            "id": cid, "name": "", "type": None, "guild_id": "", "topic": "",
+            "recipients": "", "parent_id": "", "source": source,
+        })
+        if channel.get("name") and not record["name"]:
+            record["name"] = channel["name"]
+        if record["type"] is None and channel.get("type") is not None:
+            record["type"] = channel["type"]
+        for field in ("guild_id", "topic", "parent_id"):
+            if channel.get(field) and not record[field]:
+                record[field] = channel[field]
+        recipients = channel.get("recipients") or []
+        if recipients and not record["recipients"]:
+            record["recipients"] = ", ".join(
+                user_display(r) for r in recipients if isinstance(r, dict))
+        for recipient in recipients:
+            self._note_user(recipient, "DM channel", None)
+        if channel.get("guild_id"):
+            self._note_guild({"id": channel["guild_id"]}, source)
+
+    def _note_guild(self, guild, source=""):
+        if not isinstance(guild, dict) or not guild.get("id"):
+            return
+        gid = str(guild["id"])
+        record = self.guilds.setdefault(gid, {
+            "id": gid, "name": "", "description": "", "member_count": None,
+            "features": "", "vanity_url": "", "icon": "", "source": source,
+        })
+        for field in ("name", "description", "icon", "vanity_url_code"):
+            key = "vanity_url" if field == "vanity_url_code" else field
+            if guild.get(field) and not record[key]:
+                record[key] = guild[field]
+        for field in ("member_count", "approximate_member_count"):
+            if guild.get(field) and record["member_count"] is None:
+                record["member_count"] = guild[field]
+        if guild.get("features") and not record["features"]:
+            record["features"] = ", ".join(
+                str(f) for f in guild["features"] if isinstance(f, str))
+
+    def _add_message(self, message, source, cached_at):
+        if not isinstance(message, dict) or not message.get("id"):
+            return
+        mid = message["id"]
+        existing = self.messages.get(mid)
+        # Keep the most recently cached copy: it reflects the latest edit state.
+        if existing and isinstance(existing["cached"], datetime) \
+                and isinstance(cached_at, datetime) and existing["cached"] >= cached_at:
+            return
+        self.messages[mid] = {"message": message, "source": source, "cached": cached_at}
+        sent = iso_to_datetime(message.get("timestamp")) or snowflake_to_datetime(mid)
+        self._note_user(message.get("author"), "Message author", sent)
+        for mention in message.get("mentions") or []:
+            self._note_user(mention, "Mentioned", sent)
+        if message.get("channel_id"):
+            self._note_channel({"id": message["channel_id"]}, source)
+
+
+def _decode_json(entry):
+    body = entry.decoded_body()
+    if not body:
+        return None
+    try:
+        return json.loads(body)
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+
+def find_local_account(files_found):
+    """Identify the signed-in account from the Sentry scope and Local Storage.
+
+    Returns a dict with whatever could be established: ``id``, ``username``,
+    ``email`` and ``ids`` (every account id seen, for multi-account installs).
+    """
+    account = {"id": "", "username": "", "email": "", "ids": set()}
+
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not file_found.endswith("scope_v3.json"):
+            continue
+        try:
+            with open(file_found, "r", encoding="utf-8", errors="replace") as handle:
+                scope = json.load(handle)
+        except (OSError, ValueError):
+            continue
+        user = (scope.get("scope") or {}).get("user") or {}
+        if user.get("id"):
+            account["id"] = account["id"] or str(user["id"])
+            account["ids"].add(str(user["id"]))
+        account["username"] = account["username"] or user.get("username", "")
+        account["email"] = account["email"] or user.get("email", "")
+
+    try:
+        from scripts.chromium.local_storage import leveldb_folders, read_records
+    except ImportError:
+        return account
+
+    for folder in leveldb_folders(files_found):
+        try:
+            records = list(read_records(folder))
+        except Exception:
+            continue
+        for record in sorted(records, key=lambda r: -r.sequence):
+            if record.key == "MultiAccountStore":
+                try:
+                    state = json.loads(record.value).get("_state") or {}
+                except ValueError:
+                    continue
+                for user in state.get("users") or []:
+                    if user.get("id"):
+                        account["ids"].add(str(user["id"]))
+                        if not account["id"]:
+                            account["id"] = str(user["id"])
+                        if not account["username"]:
+                            account["username"] = user.get("username", "")
+            elif record.key == "tokens":
+                try:
+                    tokens = json.loads(record.value)
+                except ValueError:
+                    continue
+                for key in tokens:
+                    if key.isdigit():
+                        account["ids"].add(key)
+                        if not account["id"]:
+                            account["id"] = key
+    return account
+
+
+_scan_cache = {}
+
+
+def scan_cache(files_found, log=None):
+    """Parse every Discord response in the cache.
+
+    Memoised on the cache entry files alone, so artifacts that also search for
+    logs or Local Storage share one scan with those that only search the cache.
+    """
+    entry_files = sorted(str(f) for f in files_found if str(f).endswith("_0"))
+    digest = hashlib.sha1(
+        "\n".join(entry_files).encode("utf-8", "replace")).hexdigest()
+    cached = _scan_cache.get(digest)
+    if cached is not None:
+        return cached
+
+    scan = DiscordCacheScan()
+    for entry in iter_entries(entry_files):
+        url = entry.url
+        if not url:
+            continue
+        scan.entry_count += 1
+        cached_at = base_time_to_datetime(entry.response_time)
+        requested_at = base_time_to_datetime(entry.request_time)
+
+        kind, owner_id, related_id = media_kind(url)
+        if kind:
+            scan.media[entry.path] = {
+                "kind": kind, "owner_id": owner_id, "related_id": related_id,
+                "url": url, "content_type": entry.content_type,
+                "size": entry.body_size, "requested": requested_at,
+                "cached": cached_at, "status": entry.status_code,
+            }
+
+        if not _STATIC_ASSET_RE.match(url):
+            parsed = urlparse(url)
+            scan.records.append({
+                "requested": requested_at, "cached": cached_at,
+                "host": parsed.netloc, "path": parsed.path,
+                "query": parsed.query, "url": url,
+                "status": entry.status_code,
+                "content_type": entry.content_type,
+                "size": entry.body_size, "kind": kind,
+                "source": entry.path,
+            })
+
+        api_match = _API_RE.match(url)
+        if not api_match:
+            continue
+        endpoint = api_match.group(2)
+        if entry.status_code and entry.status_code >= 400:
+            continue
+        scan.source_paths.add(entry.path)
+
+        try:
+            _parse_api_entry(scan, entry, endpoint, cached_at, requested_at)
+        except Exception as ex:  # a single malformed response must not stop the scan
+            if log:
+                log(f"Discord: could not parse cached '{endpoint}': {ex}")
+
+    _scan_cache[digest] = scan
+    return scan
+
+
+def _parse_api_entry(scan, entry, endpoint, cached_at, requested_at):
+    """Route one cached API response to the collection that understands it."""
+    match = _MESSAGES_RE.match(endpoint)
+    if match:
+        payload = _decode_json(entry)
+        if isinstance(payload, list):
+            for message in payload:
+                scan._add_message(message, entry.path, cached_at)
+        return
+
+    match = _MESSAGE_SEARCH_RE.match(endpoint)
+    if match:
+        payload = _decode_json(entry)
+        query = parse_qs(urlparse(entry.url).query)
+        terms = ", ".join(query.get("content", []))
+        hits = []
+        # Discord searches can filter without a search term at all (everything
+        # from an author, everything with an attachment, and so on).
+        filters = "; ".join(
+            f"{name}={', '.join(values)}"
+            for name, values in sorted(query.items())
+            if name in _SEARCH_FILTER_PARAMS)
+        if isinstance(payload, dict):
+            for group in payload.get("messages") or []:
+                for message in (group if isinstance(group, list) else [group]):
+                    scan._add_message(message, entry.path, cached_at)
+                    if isinstance(message, dict) and message.get("hit"):
+                        hits.append(message)
+            for channel in payload.get("channels") or []:
+                scan._note_channel(channel, entry.path)
+        scan.searches.append({
+            "type": "Message search",
+            "scope": f"{match.group(1).rstrip('s')} {match.group(2)}",
+            "terms": terms,
+            "filters": filters,
+            "results": (payload or {}).get("total_results") if isinstance(payload, dict) else None,
+            "requested": requested_at, "cached": cached_at,
+            "url": entry.url, "source": entry.path,
+            "hits": hits,
+        })
+        return
+
+    match = _REACTIONS_RE.match(endpoint)
+    if match:
+        payload = _decode_json(entry)
+        emoji = unquote(match.group(3))
+        if isinstance(payload, list):
+            for user in payload:
+                scan._note_user(user, "Reacted to message", cached_at)
+                scan.reactions.append({
+                    "channel_id": match.group(1), "message_id": match.group(2),
+                    "emoji": emoji, "user": user,
+                    "cached": cached_at, "source": entry.path,
+                })
+        return
+
+    match = _PROFILE_RE.match(endpoint)
+    if match:
+        payload = _decode_json(entry)
+        if isinstance(payload, dict) and payload.get("user"):
+            scan.profiles[match.group(1)] = {"profile": payload, "source": entry.path,
+                                             "cached": cached_at}
+            scan._note_user(payload["user"], "Profile viewed", cached_at)
+        return
+
+    match = _CHANNEL_RE.match(endpoint)
+    if match:
+        payload = _decode_json(entry)
+        if isinstance(payload, dict):
+            scan._note_channel(payload, entry.path)
+        return
+
+    match = _GUILD_PROFILE_RE.match(endpoint)
+    if match:
+        payload = _decode_json(entry)
+        if isinstance(payload, dict) and payload.get("name"):
+            scan._note_guild(payload, entry.path)
+        return
+
+    match = _INVITE_RE.match(endpoint)
+    if match:
+        payload = _decode_json(entry)
+        if isinstance(payload, dict) and payload.get("code"):
+            scan.invites.append({"invite": payload, "cached": cached_at,
+                                 "source": entry.path})
+            scan._note_user(payload.get("inviter"), "Invite creator", cached_at)
+            guild = payload.get("guild")
+            if guild:
+                guild = dict(guild)
+                guild.setdefault("approximate_member_count",
+                                 payload.get("approximate_member_count"))
+                scan._note_guild(guild, entry.path)
+            if payload.get("channel"):
+                channel = dict(payload["channel"])
+                if guild and guild.get("id"):
+                    channel.setdefault("guild_id", guild["id"])
+                scan._note_channel(channel, entry.path)
+        return
+
+    match = _GIF_SEARCH_RE.match(endpoint)
+    if match:
+        query = parse_qs(urlparse(entry.url).query)
+        scan.searches.append({
+            "type": "GIF search" if match.group(1) == "search" else "GIF trending",
+            "scope": ", ".join(query.get("provider", [])),
+            "terms": ", ".join(query.get("q", [])),
+            "filters": "",
+            "results": None, "requested": requested_at, "cached": cached_at,
+            "url": entry.url, "source": entry.path, "hits": [],
+        })
+        return
+
+    match = _NOTE_RE.match(endpoint)
+    if match:
+        payload = _decode_json(entry)
+        if isinstance(payload, dict) and payload.get("note"):
+            scan.notes.append({"user_id": match.group(1), "note": payload["note"],
+                               "cached": cached_at, "source": entry.path})

--- a/scripts/chromium/local_storage.py
+++ b/scripts/chromium/local_storage.py
@@ -1,0 +1,94 @@
+"""Reader for the Chromium Local Storage LevelDB store.
+
+Local Storage lives in ``Local Storage/leveldb`` and holds one record per
+``window.localStorage`` key::
+
+    META:<origin>                     metadata about the origin
+    _<origin>\\x00<encoded key>        the stored value
+
+Both the key remainder and the value start with an encoding marker byte:
+``\\x00`` means UTF-16LE, anything else means one byte per character.
+
+Records are read straight out of the LevelDB table and log files rather than
+through a compacted view, so superseded and deleted versions of a key come
+back too. That history is where drafts and selection state accumulate.
+"""
+
+from scripts.ccl import ccl_leveldb
+
+_META_PREFIX = b"META:"
+
+
+def _decode(data):
+    """Decode a Local Storage key remainder or value using its marker byte."""
+    if not data:
+        return ""
+    marker, payload = data[:1], data[1:]
+    if marker == b"\x00":
+        try:
+            return payload.decode("utf-16-le")
+        except UnicodeDecodeError:
+            return payload.decode("utf-8", "replace")
+    try:
+        return payload.decode("utf-8")
+    except UnicodeDecodeError:
+        return payload.decode("latin-1", "replace")
+
+
+class StorageRecord:
+    """One version of one Local Storage key."""
+
+    __slots__ = ("origin", "key", "value", "sequence", "state", "source")
+
+    def __init__(self, origin, key, value, sequence, state, source):
+        self.origin = origin
+        self.key = key
+        self.value = value
+        self.sequence = sequence
+        self.state = state
+        self.source = source
+
+    @property
+    def is_live(self):
+        """True when this is not a deletion tombstone."""
+        return self.state != "Deleted"
+
+
+def leveldb_folders(files_found, folder_name="leveldb"):
+    """Return the distinct LevelDB folders represented in a file list."""
+    import os
+
+    folders = {}
+    for file_found in files_found:
+        parent = os.path.dirname(str(file_found))
+        if folder_name and os.path.basename(parent) != folder_name:
+            continue
+        try:
+            real = os.path.realpath(parent)
+        except OSError:
+            real = parent
+        folders.setdefault(real, parent)
+    return list(folders.values())
+
+
+def read_records(leveldb_folder):
+    """Yield every :class:`StorageRecord` in a Local Storage LevelDB folder."""
+    database = ccl_leveldb.RawLevelDb(leveldb_folder)
+    for record in database.iterate_records_raw():
+        raw_key = record.user_key
+        if not raw_key or raw_key.startswith(_META_PREFIX):
+            continue
+        if not raw_key.startswith(b"_"):
+            continue
+        origin_bytes, separator, key_bytes = raw_key[1:].partition(b"\x00")
+        if not separator:
+            continue
+        state = record.state.name if hasattr(record.state, "name") else str(record.state)
+        yield StorageRecord(
+            origin=origin_bytes.decode("utf-8", "replace"),
+            key=_decode(key_bytes),
+            value=_decode(record.value),
+            sequence=record.seq,
+            state=state,
+            source=str(record.origin_file),
+        )

--- a/scripts/chromium/simple_cache.py
+++ b/scripts/chromium/simple_cache.py
@@ -1,0 +1,325 @@
+"""Reader for the Chromium "Simple Cache" HTTP cache format.
+
+Modern Chromium (and therefore every current Electron app) stores its HTTP
+disk cache as one file per resource, named ``<64-bit hash>_0``, inside a
+``Cache_Data`` folder. Service-worker Cache Storage uses the same format.
+
+Entry file layout (``simple_entry_format.h``)::
+
+    SimpleFileHeader           24 bytes (20 bytes of fields + 4 padding)
+        uint64 initial_magic_number   0xfcfb6d1ba7725c30
+        uint32 version                5 for current Chromium
+        uint32 key_length
+        uint32 key_hash
+    key                        key_length bytes
+    stream 1                   the HTTP response body
+    SimpleFileEOF (stream 1)   24 bytes
+    stream 0                   the serialised HttpResponseInfo
+    key SHA-256                32 bytes, only when flags & FLAG_HAS_KEY_SHA256
+    SimpleFileEOF (stream 0)   24 bytes
+
+Stream 0 holds a Chromium Pickle::
+
+    uint32 payload_size
+    int32  flags
+    int64  request_time        microseconds since 1601-01-01 UTC
+    int64  response_time
+    uint32 raw_header_length
+    raw headers                NUL-separated, status line first
+
+Entries whose name ends in ``_1``/``_s`` (secondary streams, sparse ranges)
+are not entry files and are skipped by :func:`iter_entries`.
+"""
+
+import gzip
+import os
+import re
+import struct
+import zlib
+from datetime import datetime, timedelta, timezone
+
+SIMPLE_HEADER_MAGIC = 0xFCFB6D1BA7725C30
+SIMPLE_EOF_MAGIC = 0xF4FA6F45970D41D8
+
+_FLAG_HAS_KEY_SHA256 = 2
+_HEADER_FIELDS = struct.Struct("<QIII")
+_EOF_FIELDS = struct.Struct("<QIII")
+_EOF_SIZE = 24
+# base::Time counts microseconds from 1601-01-01, the same epoch WebKit uses.
+_WINDOWS_EPOCH = datetime(1601, 1, 1, tzinfo=timezone.utc)
+# Sanity window used to recognise a timestamp field: 1970-01-01 to 2120-01-01.
+_MIN_BASE_TIME = 11644473600000000
+_MAX_BASE_TIME = 16379827200000000
+_URL_IN_KEY_RE = re.compile(r"https?://")
+_STATUS_RE = re.compile(r"^HTTP/\d(?:\.\d)?\s+(\d{3})")
+
+
+def base_time_to_datetime(value):
+    """Convert a base::Time internal value to an aware UTC datetime."""
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return ""
+    if value <= 0:
+        return ""
+    try:
+        return _WINDOWS_EPOCH + timedelta(microseconds=value)
+    except (OverflowError, OSError, ValueError):
+        return ""
+
+
+class CacheEntry:
+    """One cached HTTP response."""
+
+    __slots__ = ("path", "key", "url", "key_prefix", "request_time",
+                 "response_time", "status_code", "status_line", "headers",
+                 "body_offset", "body_size")
+
+    def __init__(self, **kwargs):
+        for slot in self.__slots__:
+            setattr(self, slot, kwargs.get(slot))
+
+    @property
+    def content_type(self):
+        return (self.headers or {}).get("content-type", "")
+
+    @property
+    def content_encoding(self):
+        return (self.headers or {}).get("content-encoding", "").strip().lower()
+
+    def read_body(self):
+        """Read the raw (still compressed) response body from disk."""
+        if not self.body_size:
+            return b""
+        try:
+            with open(self.path, "rb") as handle:
+                handle.seek(self.body_offset)
+                return handle.read(self.body_size)
+        except OSError:
+            return b""
+
+    def decoded_body(self):
+        """Read the body and undo its Content-Encoding where possible.
+
+        Returns the raw bytes when the encoding is unsupported or the data is
+        truncated, so callers can still carve or hash what survived.
+        """
+        return decode_body(self.read_body(), self.content_encoding)
+
+
+def decode_body(data, encoding):
+    """Decompress ``data`` according to an HTTP Content-Encoding value."""
+    if not data or not encoding:
+        return data
+    try:
+        if encoding == "gzip":
+            return gzip.decompress(data)
+        if encoding == "deflate":
+            try:
+                return zlib.decompress(data)
+            except zlib.error:
+                return zlib.decompress(data, -zlib.MAX_WBITS)
+        if encoding == "br":
+            import brotli  # optional dependency
+
+            return brotli.decompress(data)
+        if encoding == "zstd":
+            try:
+                from compression import zstd  # Python 3.14+
+            except ImportError:
+                import zstandard
+
+                return zstandard.ZstdDecompressor().decompress(data)
+            return zstd.decompress(data)
+    except Exception:
+        # A partially evicted or unsupported body is still worth returning raw.
+        return data
+    return data
+
+
+def key_to_url(key):
+    """Split a Chromium cache key into its isolation prefix and the URL.
+
+    Keys carry a network-isolation prefix such as ``1/0/`` or
+    ``_dk_https://site https://site `` ahead of the request URL.
+    """
+    if not key:
+        return "", ""
+    match = _URL_IN_KEY_RE.search(key)
+    if not match:
+        return key, ""
+    return key[:match.start()], key[match.start():]
+
+
+def _plausible_time(value):
+    """True when a base::Time internal value falls between 1970 and 2120."""
+    return _MIN_BASE_TIME <= value <= _MAX_BASE_TIME
+
+
+def _parse_response_info(stream0):
+    """Pull request/response times and raw headers out of an HttpResponseInfo.
+
+    The pickle is ``payload_size, flags, <times>, header_length, headers``, but
+    the number of time fields has grown across Chromium versions (an
+    original-response time was added alongside request and response time). So
+    the header block is located by its status line and the times are read
+    backwards from it, which keeps the parse version independent.
+    """
+    if len(stream0) < 28:
+        return None, None, "", {}
+
+    header_start = stream0.find(b"HTTP/")
+    if header_start >= 12:
+        header_length, = struct.unpack_from("<I", stream0, header_start - 4)
+        times = []
+        offset = header_start - 4
+        while offset >= 12:
+            candidate, = struct.unpack_from("<q", stream0, offset - 8)
+            if not _plausible_time(candidate):
+                break
+            times.insert(0, candidate)
+            offset -= 8
+        request_time = times[0] if times else None
+        response_time = times[1] if len(times) > 1 else request_time
+    else:
+        # No status line: fall back to the historical fixed layout, and only
+        # trust the times it yields if they land in a believable range. Cache
+        # Storage entries reach here and do not carry an HttpResponseInfo.
+        header_start = 28
+        request_time, response_time = struct.unpack_from("<qq", stream0, 8)
+        header_length, = struct.unpack_from("<I", stream0, 24)
+        if not _plausible_time(request_time):
+            request_time = None
+        if not _plausible_time(response_time):
+            response_time = None
+        if header_length > len(stream0) - header_start:
+            header_length = 0
+
+    raw = stream0[header_start:header_start + header_length]
+
+    headers = {}
+    status_line = ""
+    for chunk in raw.split(b"\x00"):
+        if not chunk:
+            continue
+        line = chunk.decode("latin-1")
+        if not status_line and line.startswith("HTTP/"):
+            status_line = line.strip()
+        elif ":" in line:
+            name, value = line.split(":", 1)
+            name = name.strip().lower()
+            value = value.strip()
+            # Repeated headers (set-cookie) keep every value.
+            if name in headers:
+                headers[name] = f"{headers[name]}\n{value}"
+            else:
+                headers[name] = value
+    return request_time, response_time, status_line, headers
+
+
+def read_entry(path):
+    """Parse one ``*_0`` Simple Cache entry file. Returns None if it is not one.
+
+    Only the header, key and stream 0 are read; the body stays on disk until
+    :meth:`CacheEntry.read_body` asks for it.
+    """
+    try:
+        with open(path, "rb") as handle:
+            handle.seek(0, os.SEEK_END)
+            size = handle.tell()
+            if size < _HEADER_FIELDS.size + _EOF_SIZE:
+                return None
+
+            handle.seek(0)
+            magic, _version, key_length, _key_hash = _HEADER_FIELDS.unpack(
+                handle.read(_HEADER_FIELDS.size))
+            if magic != SIMPLE_HEADER_MAGIC:
+                return None
+            if key_length <= 0 or key_length > size:
+                return None
+
+            # The header struct is padded to a multiple of 8, so the key starts
+            # at 24. Fall back to the unpadded offset if that does not hold.
+            key_offset = 24
+            handle.seek(key_offset)
+            key_bytes = handle.read(key_length)
+            if not _URL_IN_KEY_RE.search(key_bytes.decode("utf-8", "replace")):
+                handle.seek(_HEADER_FIELDS.size)
+                alternative = handle.read(key_length)
+                if _URL_IN_KEY_RE.search(alternative.decode("utf-8", "replace")):
+                    key_offset = _HEADER_FIELDS.size
+                    key_bytes = alternative
+            key = key_bytes.decode("utf-8", "replace")
+
+            handle.seek(size - _EOF_SIZE)
+            magic0, flags0, _crc0, stream0_size = _EOF_FIELDS.unpack(
+                handle.read(_EOF_FIELDS.size))
+            if magic0 != SIMPLE_EOF_MAGIC:
+                return None
+            sha_length = 32 if flags0 & _FLAG_HAS_KEY_SHA256 else 0
+            stream0_start = size - _EOF_SIZE - sha_length - stream0_size
+            if stream0_start < 0 or stream0_size < 0:
+                return None
+            handle.seek(stream0_start)
+            stream0 = handle.read(stream0_size)
+
+            body_offset = key_offset + key_length
+            body_size = 0
+            if stream0_start - _EOF_SIZE >= body_offset:
+                handle.seek(stream0_start - _EOF_SIZE)
+                magic1, _flags1, _crc1, stream1_size = _EOF_FIELDS.unpack(
+                    handle.read(_EOF_FIELDS.size))
+                available = stream0_start - _EOF_SIZE - body_offset
+                if magic1 == SIMPLE_EOF_MAGIC and 0 <= stream1_size <= available:
+                    body_size = stream1_size
+    except (OSError, struct.error, ValueError):
+        return None
+
+    request_time, response_time, status_line, headers = _parse_response_info(stream0)
+    status_match = _STATUS_RE.match(status_line or "")
+    prefix, url = key_to_url(key)
+
+    return CacheEntry(
+        path=path,
+        key=key,
+        url=url,
+        key_prefix=prefix,
+        request_time=request_time,
+        response_time=response_time,
+        status_code=int(status_match.group(1)) if status_match else None,
+        status_line=status_line,
+        headers=headers,
+        body_offset=body_offset,
+        body_size=body_size,
+    )
+
+
+def iter_entries(files_found, url_pattern=None):
+    """Yield a :class:`CacheEntry` for every Simple Cache entry in a file list.
+
+    ``url_pattern`` may be a compiled regex or a string; entries whose URL does
+    not match are skipped without their bodies ever being read. Symlinked or
+    repeated paths are only parsed once.
+    """
+    if isinstance(url_pattern, str):
+        url_pattern = re.compile(url_pattern)
+
+    seen = set()
+    for file_found in files_found:
+        file_found = str(file_found)
+        if not file_found.endswith("_0"):
+            continue
+        try:
+            real = os.path.realpath(file_found)
+        except OSError:
+            real = file_found
+        if real in seen:
+            continue
+        seen.add(real)
+
+        entry = read_entry(file_found)
+        if entry is None:
+            continue
+        if url_pattern and not url_pattern.search(entry.url):
+            continue
+        yield entry


### PR DESCRIPTION
Discord Desktop keeps no message store of its own. The client renders from REST API responses, and those responses stay in the Chromium HTTP cache after the app closes, so messages, attachments and the images themselves remain readable on disk. This parses that cache directly rather than treating it as generic browser cache, following Alex Caithness's work on treating a web app's browser artifacts as an application in their own right ([browser-forensics-presentation-2025](https://github.com/cclgroupltd/browser-forensics-presentation-2025), [mister-skinnylegs](https://github.com/cclgroupltd/mister-skinnylegs)).

## Reusable container readers

`scripts/chromium/` holds the container formats, kept free of Discord knowledge so the next Electron parser can use them:

| Module | Purpose |
| --- | --- |
| `simple_cache.py` | Chromium Simple Cache entries: key, headers, timestamps, body with Content-Encoding undone |
| `local_storage.py` | Local Storage LevelDB, returning superseded and deleted key versions alongside live ones |
| `discord_api.py` | One memoised pass over the cache decoding every Discord API response the artifacts share |

One format note worth flagging for reuse: the `HttpResponseInfo` pickle in stream 0 has gained time fields across Chromium versions. Reading it at fixed offsets silently produces year-9922 timestamps on newer entries, which was 58% of the test cache. The reader locates the header block by its status line and walks the int64 timestamps backwards from it, which is version independent.

## Artifacts

Sixteen, all under a `Discord (Desktop)` category:

Messages (LAVA conversation view, attachment images inline) · Attachments · Recovered Media · Users Seen · Channels · Servers · Invites · Searches · Reactions · Message Drafts · Client Activity · Local Storage · Channel Navigation · Gateway Sessions · Account & Application · Cache Records.

Message Drafts is the one to look at. Local Storage keeps every superseded version of the draft key, so drafts come back as a timestamped, keystroke-level history of text as it was composed.

## Metadata wording

Artifact `description` reaches both the HTML report and LAVA, while `notes` reaches LAVA only. Significance and interpretive limits are therefore in `description`, and `notes` carries mechanics: parsing sources, coverage limits, transcoding.

The wording deliberately describes what a record contains and which component wrote it, and attributes actions to the client or the log rather than to the user. It makes no claims about intent, knowledge, or what does or does not exist on Discord's servers. Statements that limit a finding are kept and expanded, because those are provable and are what stops a cache-derived report being over-read: absence of a message does not indicate it was never sent, a server record is not evidence of membership, an invite lookup is not evidence the server was joined, and whether a draft was ever sent cannot be determined from the artifact.

## Testing

Run end to end against a live macOS Discord profile (about 57,000 cache entries, 1.2 GB) with no errors, producing roughly 60,000 records across the sixteen artifacts and about 8,400 distinct media files, all valid images with no broken report links. Cross-platform path matching was verified separately against a synthetic extraction using a Windows `AppData/Roaming/discordptb` layout, where all sixteen artifacts also fired. No test data is included in this branch.

`Brotli` is added to requirements for the brotli-encoded API responses; gzip and zstd are handled through the standard library.