### PR TITLE
Cite the desktop sample corpora in the Discord artifacts

### DIFF
--- a/scripts/artifacts/discordAccount.py
+++ b/scripts/artifacts/discordAccount.py
@@ -32,6 +32,10 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "user",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 41 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 36 rows",
+        },
     },
 }
 

--- a/scripts/artifacts/discordCacheRecords.py
+++ b/scripts/artifacts/discordCacheRecords.py
@@ -27,6 +27,10 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "list",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 29083 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 189 rows",
+        },
     },
 }
 

--- a/scripts/artifacts/discordContacts.py
+++ b/scripts/artifacts/discordContacts.py
@@ -30,6 +30,10 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "users",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 590 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 10 rows",
+        },
     },
     "discordChannels": {
         "name": "Discord Channels",
@@ -60,6 +64,10 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "hash",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 117 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 4 rows",
+        },
     },
     "discordGuilds": {
         "name": "Discord Servers",
@@ -91,6 +99,10 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "server",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 25 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 2 rows",
+        },
     },
     "discordInvites": {
         "name": "Discord Invites",
@@ -116,6 +128,10 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "link",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 27 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 1 rows",
+        },
     },
 }
 

--- a/scripts/artifacts/discordLocalStorage.py
+++ b/scripts/artifacts/discordLocalStorage.py
@@ -20,6 +20,10 @@ __artifacts_v2__ = {
         "paths": ('*/discord*/Local Storage/leveldb/*',),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "edit-3",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 64 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 64 rows",
+        },
     },
     "discordActivity": {
         "name": "Discord Client Activity",
@@ -43,6 +47,10 @@ __artifacts_v2__ = {
         "paths": ('*/discord*/Local Storage/leveldb/*',),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "activity",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 303 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 303 rows",
+        },
     },
     "discordLocalStorage": {
         "name": "Discord Local Storage",
@@ -63,6 +71,10 @@ __artifacts_v2__ = {
         "paths": ('*/discord*/Local Storage/leveldb/*',),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "database",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 654 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 654 rows",
+        },
     },
 }
 

--- a/scripts/artifacts/discordLogs.py
+++ b/scripts/artifacts/discordLogs.py
@@ -24,6 +24,10 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "navigation",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 461 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 153 rows",
+        },
     },
     "discordGatewaySessions": {
         "name": "Discord Gateway Sessions",
@@ -48,6 +52,10 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "plug",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 1676 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 194 rows",
+        },
     },
 }
 

--- a/scripts/artifacts/discordMedia.py
+++ b/scripts/artifacts/discordMedia.py
@@ -29,6 +29,10 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "image",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 12424 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 84 rows",
+        },
     },
 }
 

--- a/scripts/artifacts/discordMessages.py
+++ b/scripts/artifacts/discordMessages.py
@@ -31,6 +31,10 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "message-circle",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 12940 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 164 rows",
+        },
         "data_views": {
             "conversation": {
                 "conversationDiscriminatorColumn": "Channel ID",
@@ -74,6 +78,10 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "paperclip",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 1022 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 12 rows",
+        },
     },
 }
 

--- a/scripts/artifacts/discordSearches.py
+++ b/scripts/artifacts/discordSearches.py
@@ -25,6 +25,10 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "search",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 215 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 1 rows",
+        },
     },
     "discordReactions": {
         "name": "Discord Reactions",
@@ -52,6 +56,10 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "smile",
+        "sample_data": {
+            "discord_macos": "Discord 0.0.402 macOS | 335 rows",
+            "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 3 rows",
+        },
     },
 }
 


### PR DESCRIPTION
The desktop test corpora on the local data drive now carry their own `samples.json`, mirroring the registry the iOS images use for iLEAPP. Each sample records a `match` block (zip path relative to the registry, plus sha256), `platform`, `os_version`, `app_versions` and `notes`.

This PR adds the matching half: a `sample_data` block on every Discord artifact naming the corpora it has been run against and the rows each produced. Coverage is then recorded where the artifact is defined rather than in a session log, and the processor ignores the key exactly as iLEAPP's does.

Example:

```python
"sample_data": {
    "discord_macos": "Discord 0.0.402 macOS | 12940 rows",
    "discord_win_ptb": "Discord 0.0.402 Windows PTB layout | 164 rows",
},
```

## Verification

- All 16 artifacts carry `sample_data`, and every key they cite exists in the registry.
- Counts come from live runs, not estimates. The Windows figures were re-verified by resolving the corpus through the registry, checking its sha256, running the parser fresh and diffing all 16 declared counts against the result: no mismatches.
- Artifacts still load and `admin/scripts/module_info.py` still runs, since it reads metadata through `.get()` and is unaffected by a new key.

No corpus data is included here, and none should be: the macOS sample is personal account data held privately on the data drive.