### PR TITLE
Add a Signal Desktop parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ DLEAPP is also meant to be a home for parsers that don't fit neatly into any of 
 | --- | --- |
 | **Wire** (desktop) | Accounts, devices, conversations, messages, calls, attachments, cookies, service-worker cache, and media recovered by decrypting cached asset blobs. |
 | **Discord** (desktop) | Messages, attachments and recovered media, servers, channels, users, searches, reactions, message drafts, client activity, channel navigation, gateway sessions, account and application details, and a full cache index. |
+| **Signal** (desktop) | Messages, attachments decrypted from disk, conversations and groups, calls, reactions, protocol sessions and identity keys, and account details. Requires the database credential — see below. |
 
 Discord Desktop keeps no message database of its own: the client renders from
 REST API responses, and those responses stay in the Chromium HTTP cache. The
@@ -28,6 +29,32 @@ The Chromium container formats these parsers rely on live in `scripts/chromium/`
 (Simple Cache reader, Local Storage LevelDB reader) and are reusable by any
 future Electron application parser. More desktop-application parsers will be
 added over time.
+
+### Signal Desktop needs a credential
+
+Signal encrypts its message database with SQLCipher, and encrypts every file in
+`attachments.noindex` with a key held inside that database. Recent versions wrap
+the database key with the OS credential store, so it is **not** in the profile:
+
+* macOS — login Keychain, service `Signal Safe Storage`
+* Windows — Credential Manager
+
+Capture it from the host and pass it in. DLEAPP accepts the credential, the
+64 character database key itself, or a file holding either:
+
+```
+python3 dleapp.py -t fs -i <profile> -o <output> --signal-key
+```
+
+Given the flag with no value it prompts without echo, which keeps the secret out
+of shell history and the process list. The GUI has an equivalent Signal key
+field. A file named `signal_password.txt` beside the extraction is also picked
+up, which suits batch runs. Older profiles that still hold a plaintext `key` in
+`config.json` need nothing at all.
+
+Without a credential the Signal artifacts report why and produce no rows, rather
+than failing silently. `scripts/sqlcipher_decrypt.py` is the same pure-python
+reader ALEAPP and iLEAPP use, so it needs no native SQLCipher build.
 
 If you want to contribute hit me up on twitter: https://twitter.com/AlexisBrignoni   
 

--- a/dleapp.py
+++ b/dleapp.py
@@ -1,6 +1,8 @@
 import json
 import argparse
+import getpass
 import io
+import os
 import os.path
 import typing
 import scripts.report as report
@@ -20,6 +22,40 @@ from scripts.context import Context
 from scripts.lavafuncs import lava_json_name
 
 leapp_name = "DLEAPP"
+
+# Sentinel meaning "--signal-key was given with no value", which asks for a
+# prompt instead. Secrets are gathered here, before processing starts, never
+# from inside an artifact: artifacts run in a loop and, under the GUI, off the
+# main thread, so a prompt there would stall the run or deadlock the interface.
+PROMPT_FOR_SECRET = object()
+
+
+def resolve_supplied_secret(value, label):
+    '''Turn a --<app>-key argument into the secret itself.
+
+    The argument may be the secret, the path to a file holding it, or the
+    sentinel asking for an interactive prompt. Reading from a file, or being
+    prompted, keeps the secret out of shell history and the process list.
+    '''
+    if value is None:
+        return None
+    if value is PROMPT_FOR_SECRET:
+        if not sys.stdin.isatty():
+            raise argparse.ArgumentError(
+                None, f'{label} was given with no value, but this is not an interactive '
+                      'terminal so there is nothing to prompt. Pass the value or a file path.')
+        entered = getpass.getpass(f'{label} (input hidden): ').strip()
+        if not entered:
+            raise argparse.ArgumentError(None, f'No {label} was entered.')
+        return entered
+    if os.path.isfile(value):
+        with open(value, 'r', encoding='utf-8', errors='replace') as secret_file:
+            contents = secret_file.read(4096).strip()
+        if not contents:
+            raise argparse.ArgumentError(None, f'The file given for {label} is empty: {value}')
+        return contents
+    return value.strip()
+
 
 def validate_args(args):
     if args.artifact_paths or args.create_profile_casedata:
@@ -180,6 +216,14 @@ def main():
                               "This argument is meant to be used alone, without any other arguments."))
     parser.add_argument('--custom_output_folder', required=False, action="store", help="Custom name for the output folder")
     parser.add_argument('--custom_artifacts_path', required=False, action="store", help="Additional path to load artifacts from (e.g., scripts/alternate_artifacts)")
+    parser.add_argument('--signal-key', dest='signal_key', required=False, nargs='?',
+                        const=PROMPT_FOR_SECRET, default=None, metavar='VALUE_OR_FILE',
+                        help=("Credential for a Signal Desktop profile, needed because Signal "
+                              "encrypts its database and attachments. Accepts the OS credential "
+                              "store password ('Signal Safe Storage' in the macOS Keychain, or the "
+                              "Windows Credential Manager), the 64 character database key itself, "
+                              "or the path to a file holding either. Give the flag with no value "
+                              "to be prompted without the secret reaching your shell history."))
 
 
     # Check if no arguments were provided
@@ -317,6 +361,13 @@ def main():
     wrap_text = args.wrap_text
     output_path = os.path.abspath(args.output_path)
     custom_output_folder = args.custom_output_folder
+
+    # Gather any application secrets now, while the terminal is still ours
+    try:
+        Context.set_app_secret('signal', resolve_supplied_secret(args.signal_key, 'Signal key'))
+    except argparse.ArgumentError as secret_error:
+        print(secret_error)
+        return
 
     # File system extractions contain paths > 260 char, which causes problems
     # This fixes the problem by prefixing \\?\ on each windows path.

--- a/dleappGUI.py
+++ b/dleappGUI.py
@@ -3,6 +3,7 @@
 import tkinter as tk
 import typing
 import json
+import os
 import dleapp
 import webbrowser
 import base64
@@ -454,6 +455,12 @@ def process(casedata):
         casedata = {key: value.get() for key, value in casedata.items()}
         out_params = OutputParameters(output_folder, output_folder_name_entry.get().strip())
         Context.set_output_params(out_params)
+        # A field value may be the secret itself or a file holding it
+        signal_key = signal_key_entry.get().strip()
+        if signal_key and os.path.isfile(signal_key):
+            with open(signal_key, 'r', encoding='utf-8', errors='replace') as signal_key_file:
+                signal_key = signal_key_file.read(4096).strip()
+        Context.set_app_secret('signal', signal_key or None)
         wrap_text = True
         bottom_frame.pack_forget()
         mlist_frame.pack_forget()
@@ -866,6 +873,16 @@ output_folder_name_entry.configure(
     validate='key',
     validatecommand=(main_window.register(allow_output_folder_name_chars), '%P'))
 output_folder_name_entry.pack(side='left', fill='x', expand=True)
+
+# Secrets for applications that encrypt their data are gathered here, before
+# processing starts. An artifact cannot ask for one mid-run: modules execute on
+# a worker thread, so a dialog raised from there would deadlock the interface.
+app_secret_row = ttk.Frame(output_frame)
+app_secret_row.pack(fill='x', padx=5, pady=(0, 4))
+ttk.Label(app_secret_row, text='Signal key:').pack(side='left', padx=(0, 5))
+signal_key_entry = ttk.Entry(app_secret_row, show='•')
+signal_key_entry.pack(side='left', fill='x', expand=True)
+ttk.Label(app_secret_row, text='(optional)').pack(side='left', padx=(5, 0))
 
 mlist_frame = ttk.LabelFrame(main_window, text=' Available Modules: ', name='f_list')
 mlist_frame.pack(padx=14, pady=5, expand=True, fill='both')

--- a/scripts/artifacts/signalAccount.py
+++ b/scripts/artifacts/signalAccount.py
@@ -1,0 +1,184 @@
+__artifacts_v2__ = {
+    "signalAccount": {
+        "name": "Signal Account & Application",
+        "description": "The account registered to this Signal Desktop "
+                       "installation and how the client is configured, from the "
+                       "database's own key-value store together with the "
+                       "unencrypted profile files. Includes the linked device "
+                       "name and when it was created, which dates the link "
+                       "between this computer and the phone that owns the "
+                       "account.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "PyCryptodome; the Signal database credential for the "
+                        "account fields",
+        "category": "Signal (Desktop)",
+        "notes": "Key material is reported as present or absent, never printed: "
+                 "the store also holds the account password, master key, "
+                 "profile key and storage keys, which would let the account be "
+                 "impersonated. The unencrypted profile files are reported even "
+                 "when no credential is available.",
+        "paths": (
+            '*/Signal*/sql/db.sqlite',
+            '*/Signal*/config.json',
+            '*/Signal*/ephemeral.json',
+            '*/Signal*/Preferences',
+            '*/Signal*/Local State',
+            '*/signal_password.txt',
+            '*/signal-keychain.txt',
+            '*/signal_db_key.txt',
+        ),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "user",
+        "sample_data": {
+            "signal_macos": "Signal Desktop macOS, credential supplied | 35 rows",
+        },
+    },
+}
+
+import json
+import os
+
+from scripts import signal_desktop
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+# Items whose value is key material or a credential. Their presence is
+# evidence the account is registered; their value would allow impersonation.
+_SECRET_ITEMS = {
+    "password", "masterKey", "profileKey", "storageKey", "accountEntropyPool",
+    "backupMediaRootKey", "identityKeyMap", "storageCredentials", "groupCredentials",
+    "callLinkAuthCredentials", "senderCertificate", "senderCertificateNoE164",
+    "usernameLink", "manifestRecordIkm", "signedKeyId", "subscriberId",
+}
+
+# Items worth reporting by value, with a readable label.
+_REPORTED_ITEMS = {
+    "uuid_id": "Account Service ID (ACI)",
+    "pni": "Account Phone Number Identity (PNI)",
+    "number_id": "Registered Phone Number",
+    "device_name": "Linked Device Name",
+    "deviceCreatedAt": "Device Linked",
+    "regionCode": "Region Code",
+    "synced_at": "Last Storage Sync",
+    "unreadCount": "Unread Count",
+    "universalExpireTimer": "Default Disappearing Timer (s)",
+    "phoneNumberSharingMode": "Phone Number Sharing",
+    "phoneNumberDiscoverability": "Phone Number Discoverability",
+    "read-receipt-setting": "Read Receipts Enabled",
+    "typingIndicators": "Typing Indicators Enabled",
+    "sealedSenderIndicators": "Sealed Sender Indicators",
+    "linkPreviews": "Link Previews Enabled",
+    "hasStoriesDisabled": "Stories Disabled",
+    "backupTier": "Backup Tier",
+    "blocked": "Blocked Numbers",
+    "blocked-uuids": "Blocked Service IDs",
+    "blocked-groups": "Blocked Groups",
+    "pinnedConversationIds": "Pinned Conversations",
+    "emojiSkinToneDefault": "Default Emoji Skin Tone",
+    "keepMutedChatsArchived": "Keep Muted Chats Archived",
+}
+
+_TIMESTAMP_ITEMS = {"deviceCreatedAt", "synced_at"}
+
+
+def _read_json(path):
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            return json.load(handle)
+    except (OSError, ValueError):
+        return None
+
+
+@artifact_processor
+def signalAccount(context):
+    data_headers = ("Property", "Value", "Source File")
+    data_list = []
+    files_found = [str(f) for f in context.get_files_found()]
+    source_path = ""
+
+    def add(prop, value, path):
+        if value not in (None, "", [], {}):
+            data_list.append((prop, str(value), context.get_relative_path(path)))
+
+    # Unencrypted profile files first, so the artifact still reports something
+    # useful when no credential was supplied.
+    for file_found in files_found:
+        name = os.path.basename(file_found)
+        if name == "config.json":
+            config = _read_json(file_found)
+            if not isinstance(config, dict):
+                continue
+            source_path = source_path or file_found
+            if config.get("key"):
+                add("Database Key Storage", "Plaintext 'key' in config.json "
+                    "(older Signal Desktop)", file_found)
+            if config.get("encryptedKey"):
+                add("Database Key Storage", "'encryptedKey', wrapped with the OS "
+                    "credential store", file_found)
+            for setting in ("mediaPermissions", "mediaCameraPermissions"):
+                if setting in config:
+                    add(f"Setting: {setting}", config[setting], file_found)
+        elif name == "ephemeral.json":
+            ephemeral = _read_json(file_found)
+            if not isinstance(ephemeral, dict):
+                continue
+            source_path = source_path or file_found
+            for key in ("theme-setting", "spell-check", "localeOverride", "system-tray-setting"):
+                if key in ephemeral:
+                    add(f"Setting: {key}", ephemeral[key], file_found)
+            window = ephemeral.get("window") or {}
+            if window:
+                add("Window Bounds",
+                    f"{window.get('width')}x{window.get('height')} "
+                    f"at x={window.get('x')} y={window.get('y')} "
+                    f"maximized={window.get('maximized')}", file_found)
+
+    connection, note = signal_desktop.open_database(files_found, log=logfunc)
+    if connection is None:
+        signal_desktop.explain(note, logfunc)
+        add("Database", f"Not opened: {note}", source_path or "config.json")
+        return data_headers, data_list, source_path
+
+    database_path = next(iter(signal_desktop.database_files(files_found)), "")
+    source_path = database_path or source_path
+    add("Database", f"Opened, {note}", database_path)
+
+    present_secrets = []
+    for item_id, blob in connection.execute("SELECT id, json FROM items"):
+        try:
+            value = json.loads(blob).get("value")
+        except (ValueError, TypeError):
+            continue
+        if item_id in _SECRET_ITEMS:
+            if value:
+                present_secrets.append(item_id)
+            continue
+        label = _REPORTED_ITEMS.get(item_id)
+        if not label:
+            continue
+        if item_id in _TIMESTAMP_ITEMS:
+            add(label, signal_desktop.js_ms_to_datetime(value), database_path)
+        elif isinstance(value, (list, dict)):
+            add(label, json.dumps(value)[:500], database_path)
+        else:
+            add(label, value, database_path)
+
+    if present_secrets:
+        add("Key Material Present (values withheld)",
+            ", ".join(sorted(present_secrets)), database_path)
+
+    for label, query in (
+            ("Conversations", "SELECT COUNT(*) FROM conversations"),
+            ("Messages", "SELECT COUNT(*) FROM messages"),
+            ("Attachments", "SELECT COUNT(*) FROM message_attachments"),
+            ("Calls", "SELECT COUNT(*) FROM callsHistory"),
+            ("Protocol Sessions", "SELECT COUNT(*) FROM sessions")):
+        try:
+            add(f"Records: {label}", connection.execute(query).fetchone()[0], database_path)
+        except Exception:
+            continue
+
+    connection.close()
+    logfunc(f"Signal Account & Application: {len(data_list)} property value(s).")
+    return data_headers, data_list, source_path

--- a/scripts/artifacts/signalContacts.py
+++ b/scripts/artifacts/signalContacts.py
@@ -1,0 +1,276 @@
+__artifacts_v2__ = {
+    "signalConversations": {
+        "name": "Signal Conversations",
+        "description": "Direct conversations and groups held in the Signal "
+                       "Desktop database, with the phone number and service "
+                       "identifiers Signal recorded for each, the number of "
+                       "messages recovered and the span they cover.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "PyCryptodome; the Signal database credential",
+        "category": "Signal (Desktop)",
+        "notes": "A conversation exists here once Signal has learned of the "
+                 "account, which includes accounts that were never messaged "
+                 "from this device. The message count distinguishes those.",
+        "paths": (
+            '*/Signal*/sql/db.sqlite',
+            '*/Signal*/config.json',
+            '*/signal_password.txt',
+            '*/signal-keychain.txt',
+            '*/signal_db_key.txt',
+        ),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "users",
+        "sample_data": {
+            "signal_macos": "Signal Desktop macOS, credential supplied | 173 rows",
+        },
+    },
+    "signalCalls": {
+        "name": "Signal Calls",
+        "description": "Call history from the Signal Desktop database: who the "
+                       "call was with, whether it was audio or video, its "
+                       "direction, how it ended and when.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "PyCryptodome; the Signal database credential",
+        "category": "Signal (Desktop)",
+        "notes": "Signal Desktop records calls it observed. A call placed or "
+                 "answered on a phone linked to the same account may not appear "
+                 "here, so an absent call is not evidence no call took place.",
+        "paths": (
+            '*/Signal*/sql/db.sqlite',
+            '*/Signal*/config.json',
+            '*/signal_password.txt',
+            '*/signal-keychain.txt',
+            '*/signal_db_key.txt',
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "phone",
+        "sample_data": {
+            "signal_macos": "Signal Desktop macOS, credential supplied | 15 rows",
+        },
+    },
+    "signalSessions": {
+        "name": "Signal Sessions & Identity Keys",
+        "description": "Signal Protocol sessions and identity keys the client "
+                       "holds. A session exists for each device the client has "
+                       "exchanged messages with, and an identity key record is "
+                       "kept for each account whose key it has seen, together "
+                       "with when that key was first recorded.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "PyCryptodome; the Signal database credential",
+        "category": "Signal (Desktop)",
+        "notes": "These records show cryptographic contact at the protocol "
+                 "level, which can name accounts that no longer appear in any "
+                 "message. Key material itself is not reported.",
+        "paths": (
+            '*/Signal*/sql/db.sqlite',
+            '*/Signal*/config.json',
+            '*/signal_password.txt',
+            '*/signal-keychain.txt',
+            '*/signal_db_key.txt',
+        ),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "key",
+        "sample_data": {
+            "signal_macos": "Signal Desktop macOS, credential supplied | 165 rows",
+        },
+    },
+}
+
+import json
+from datetime import datetime, timezone
+
+from scripts import signal_desktop
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+_EPOCH_MIN = datetime.min.replace(tzinfo=timezone.utc)
+
+_CALL_TYPES = {"Audio": "Audio", "Video": "Video", "Group": "Group call", "Adhoc": "Call link"}
+_CALL_DIRECTIONS = {"Incoming": "Incoming", "Outgoing": "Outgoing"}
+
+
+def _source(files_found):
+    return next(iter(signal_desktop.database_files(files_found)), "")
+
+
+@artifact_processor
+def signalConversations(context):
+    data_headers = (
+        "Conversation", "Type", "Phone Number", "Messages Recovered",
+        ("First Message", "datetime"), ("Last Message", "datetime"),
+        ("Last Active", "datetime"), "Profile Name", "Service ID", "Group ID",
+        "Members", "Conversation ID", "Source File",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    connection, note = signal_desktop.open_database(files_found, log=logfunc)
+    if connection is None:
+        signal_desktop.explain(note, logfunc)
+        return data_headers, [], ""
+
+    counts, spans = {}, {}
+    for conversation_id, count, first, last in connection.execute(
+            "SELECT conversationId, COUNT(*), MIN(sent_at), MAX(sent_at) "
+            "FROM messages GROUP BY conversationId"):
+        counts[conversation_id] = count
+        spans[conversation_id] = (first, last)
+
+    data_list = []
+    query = """SELECT id, type, name, profileFullName, profileName, e164, serviceId,
+                      groupId, members, active_at FROM conversations"""
+    for (cid, ctype, name, full, profile, e164, service_id,
+         group_id, members, active_at) in connection.execute(query):
+        first, last = spans.get(cid, (None, None))
+        member_list = ""
+        if members:
+            try:
+                parsed = json.loads(members) if members.strip().startswith("[") else members.split()
+                member_list = ", ".join(str(m) for m in parsed) if isinstance(parsed, list) else str(members)
+            except (ValueError, AttributeError):
+                member_list = str(members)
+        data_list.append((
+            name or full or profile or e164 or cid,
+            "Group" if ctype == "group" else "Direct",
+            e164 or "",
+            counts.get(cid, 0),
+            signal_desktop.js_ms_to_datetime(first),
+            signal_desktop.js_ms_to_datetime(last),
+            signal_desktop.js_ms_to_datetime(active_at),
+            full or profile or "",
+            service_id or "",
+            group_id or "",
+            member_list,
+            cid or "",
+            context.get_relative_path(_source(files_found)),
+        ))
+
+    connection.close()
+    data_list.sort(key=lambda row: (-row[3], (row[0] or "").lower()))
+    groups = sum(1 for row in data_list if row[1] == "Group")
+    logfunc(f"Signal Conversations: {len(data_list)} conversation(s), {groups} group(s).")
+    return data_headers, data_list, _source(files_found)
+
+
+@artifact_processor
+def signalCalls(context):
+    data_headers = (
+        ("Started", "datetime"), "With", "Call Type", "Direction", "Status",
+        ("Ended", "datetime"), "Duration (s)", "Ringer", "Call ID", "Peer ID",
+        "Source File",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    connection, note = signal_desktop.open_database(files_found, log=logfunc)
+    if connection is None:
+        signal_desktop.explain(note, logfunc)
+        return data_headers, [], ""
+
+    labels = signal_desktop.conversation_labels(connection)
+    by_service = {}
+    for service_id, cid in connection.execute(
+            "SELECT serviceId, id FROM conversations WHERE serviceId IS NOT NULL"):
+        by_service[service_id.lower()] = labels.get(cid, cid)
+
+    data_list = []
+    try:
+        rows = connection.execute("""SELECT callId, peerId, ringerId, mode, type, direction,
+                                            status, timestamp, endedTimestamp FROM callsHistory""")
+    except Exception as ex:
+        logfunc(f"Signal Calls: call history unavailable ({ex}).")
+        connection.close()
+        return data_headers, [], ""
+
+    for (call_id, peer_id, ringer_id, mode, call_type, direction,
+         status, timestamp, ended) in rows:
+        duration = ""
+        if timestamp and ended and ended > timestamp:
+            duration = round((ended - timestamp) / 1000)
+        data_list.append((
+            signal_desktop.js_ms_to_datetime(timestamp),
+            by_service.get((peer_id or "").lower()) or labels.get(peer_id, peer_id or ""),
+            _CALL_TYPES.get(call_type, call_type or mode or ""),
+            _CALL_DIRECTIONS.get(direction, direction or ""),
+            status or "",
+            signal_desktop.js_ms_to_datetime(ended),
+            duration,
+            by_service.get((ringer_id or "").lower()) or (ringer_id or ""),
+            str(call_id or ""),
+            peer_id or "",
+            context.get_relative_path(_source(files_found)),
+        ))
+
+    connection.close()
+    data_list.sort(key=lambda row: row[0] if isinstance(row[0], datetime) else _EPOCH_MIN)
+    logfunc(f"Signal Calls: {len(data_list)} call(s).")
+    return data_headers, data_list, _source(files_found)
+
+
+@artifact_processor
+def signalSessions(context):
+    data_headers = (
+        "Record", "Account", "Service ID", "Device ID", ("First Seen", "datetime"),
+        "Verified State", "Non-Blocking Approval", "Source File",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    connection, note = signal_desktop.open_database(files_found, log=logfunc)
+    if connection is None:
+        signal_desktop.explain(note, logfunc)
+        return data_headers, [], ""
+
+    labels = signal_desktop.conversation_labels(connection)
+    by_service = {}
+    for service_id, cid in connection.execute(
+            "SELECT serviceId, id FROM conversations WHERE serviceId IS NOT NULL"):
+        by_service[service_id.lower()] = labels.get(cid, cid)
+
+    data_list = []
+    try:
+        rows = connection.execute(
+            "SELECT conversationId, serviceId, deviceId FROM sessions")
+        for conversation_id, service_id, device_id in rows:
+            label = labels.get(conversation_id, "")
+            if not label and service_id:
+                label = by_service.get(service_id.lower(), "")
+            data_list.append((
+                "Session",
+                label or conversation_id or "",
+                service_id or "",
+                device_id if device_id is not None else "",
+                "", "", "",
+                context.get_relative_path(_source(files_found)),
+            ))
+    except Exception as ex:
+        logfunc(f"Signal Sessions: sessions table unavailable ({ex}).")
+
+    try:
+        for row in connection.execute("SELECT id, json FROM identityKeys"):
+            identity_id, blob = row
+            try:
+                record = json.loads(blob) if blob else {}
+            except (ValueError, TypeError):
+                record = {}
+            data_list.append((
+                "Identity key",
+                by_service.get((identity_id or "").lower(), ""),
+                identity_id or "",
+                "",
+                signal_desktop.js_ms_to_datetime(record.get("timestamp")),
+                record.get("verified", ""),
+                "Yes" if record.get("nonblockingApproval") else "",
+                context.get_relative_path(_source(files_found)),
+            ))
+    except Exception as ex:
+        logfunc(f"Signal Sessions: identityKeys table unavailable ({ex}).")
+
+    connection.close()
+    data_list.sort(key=lambda row: (row[0], (row[1] or "").lower()))
+    sessions = sum(1 for row in data_list if row[0] == "Session")
+    logfunc(f"Signal Sessions & Identity Keys: {sessions} session(s), "
+            f"{len(data_list) - sessions} identity key record(s).")
+    return data_headers, data_list, _source(files_found)

--- a/scripts/artifacts/signalMessages.py
+++ b/scripts/artifacts/signalMessages.py
@@ -1,0 +1,352 @@
+__artifacts_v2__ = {
+    "signalMessages": {
+        "name": "Signal Messages",
+        "description": "Messages from the Signal Desktop database. Signal keeps "
+                       "them in a SQLCipher database whose key is wrapped with "
+                       "the OS credential store, so the credential has to be "
+                       "supplied with --signal-key, the Signal key field in the "
+                       "GUI, or a file beside the extraction. Attachments that "
+                       "decrypt are embedded against their message.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "PyCryptodome; the Signal database credential",
+        "category": "Signal (Desktop)",
+        "notes": "Message bodies come from the messages table. A row with an "
+                 "empty body is not necessarily an empty message: it may be a "
+                 "view-once message that was opened, a message whose body was "
+                 "erased, or an event such as a key change. The message type is "
+                 "reported so those cases are distinguishable.",
+        "paths": (
+            '*/Signal*/sql/db.sqlite',
+            '*/Signal*/config.json',
+            '*/Signal*/attachments.noindex/*/*',
+            '*/signal_password.txt',
+            '*/signal-keychain.txt',
+            '*/signal_db_key.txt',
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "message-square",
+        "sample_data": {
+            "signal_macos": "Signal Desktop macOS, credential supplied | 3837 rows",
+        },
+        "data_views": {
+            "conversation": {
+                "conversationDiscriminatorColumn": "Conversation ID",
+                "conversationLabelColumn": "Conversation",
+                "textColumn": "Message",
+                "timeColumn": "Sent",
+                "directionColumn": "Direction",
+                "directionSentValue": "Outgoing",
+                "senderColumn": "Sender",
+                "mediaColumn": "Attachments",
+            }
+        },
+    },
+    "signalAttachments": {
+        "name": "Signal Attachments",
+        "description": "Files shared in Signal conversations, decrypted from "
+                       "attachments.noindex. Each stored file is encrypted with "
+                       "its own key held in the database, so the files cannot be "
+                       "read without it. Every recovered file is checked against "
+                       "the message authentication code and, where the database "
+                       "recorded one, its SHA-256.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "PyCryptodome; the Signal database credential",
+        "category": "Signal (Desktop)",
+        "notes": "Signal pads a stored attachment with zeroes to hide its true "
+                 "length, so the file is truncated to the size the database "
+                 "records. The Verified column reports whether the recovered "
+                 "bytes matched the SHA-256 the database holds for the original.",
+        "paths": (
+            '*/Signal*/sql/db.sqlite',
+            '*/Signal*/config.json',
+            '*/Signal*/attachments.noindex/*/*',
+            '*/signal_password.txt',
+            '*/signal-keychain.txt',
+            '*/signal_db_key.txt',
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "paperclip",
+        "sample_data": {
+            "signal_macos": "Signal Desktop macOS, credential supplied | 297 rows",
+        },
+    },
+    "signalReactions": {
+        "name": "Signal Reactions",
+        "description": "Emoji reactions recorded against messages, with the "
+                       "account that sent each one and the message it targets.",
+        "author": "@AlexisBrignoni",
+        "creation_date": "2026-07-26",
+        "last_update_date": "2026-07-26",
+        "requirements": "PyCryptodome; the Signal database credential",
+        "category": "Signal (Desktop)",
+        "notes": "A reaction is stored separately from the message it targets, "
+                 "so it survives here even where the message body is empty.",
+        "paths": (
+            '*/Signal*/sql/db.sqlite',
+            '*/Signal*/config.json',
+            '*/signal_password.txt',
+            '*/signal-keychain.txt',
+            '*/signal_db_key.txt',
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "smile",
+        "sample_data": {
+            "signal_macos": "Signal Desktop macOS, credential supplied | 390 rows",
+        },
+    },
+}
+
+import os
+from datetime import datetime, timezone
+
+from scripts import signal_desktop
+from scripts.ilapfuncs import artifact_processor, check_in_embedded_media, logfunc
+
+_EPOCH_MIN = datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _sender(labels, self_ids, message_type, source_service_id, conversation_id):
+    if message_type == "outgoing":
+        return "Local user"
+    if source_service_id:
+        key = source_service_id.lower()
+        if key in self_ids:
+            return "Local user"
+        for cid, label in labels.items():
+            if cid == source_service_id:
+                return label
+    return labels.get(conversation_id, conversation_id or "")
+
+
+def _service_id_labels(connection, labels):
+    """Map a service id to its conversation label, for sender resolution."""
+    mapping = {}
+    try:
+        rows = connection.execute(
+            "SELECT serviceId, id FROM conversations WHERE serviceId IS NOT NULL")
+    except Exception:
+        return mapping
+    for service_id, cid in rows:
+        if service_id:
+            mapping[service_id.lower()] = labels.get(cid, cid)
+    return mapping
+
+
+@artifact_processor
+def signalMessages(context):
+    data_headers = (
+        ("Sent", "datetime"), "Direction", "Sender", "Conversation", "Message",
+        ("Attachments", "media"), "Attachment Names", "Message Type",
+        ("Received", "datetime"), ("Server Timestamp", "datetime"),
+        "Read Status", "View Once", "Erased", "Expires In (s)",
+        ("Expires At", "datetime"), "Conversation ID", "Message ID", "Source File",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    connection, note = signal_desktop.open_database(files_found, log=logfunc)
+    if connection is None:
+        signal_desktop.explain(note, logfunc)
+        return data_headers, [], ""
+
+    labels = signal_desktop.conversation_labels(connection)
+    self_ids = signal_desktop.self_service_ids(connection)
+    by_service = _service_id_labels(connection, labels)
+    root = signal_desktop.attachments_root(files_found)
+
+    # Attachments belonging to each message, decrypted once and shared with the
+    # attachment artifact through the media store's own de-duplication.
+    attachments = {}
+    try:
+        rows = connection.execute("""
+            SELECT messageId, path, localKey, size, contentType, fileName, plaintextHash
+            FROM message_attachments WHERE path IS NOT NULL ORDER BY orderInMessage""")
+        for message_id, path, local_key, size, content_type, file_name, plain_hash in rows:
+            attachments.setdefault(message_id, []).append(
+                (path, local_key, size, content_type, file_name, plain_hash))
+    except Exception as ex:
+        logfunc(f"Signal Messages: attachment table unavailable ({ex}).")
+
+    data_list = []
+    query = """SELECT id, conversationId, type, body, sent_at, received_at_ms, serverTimestamp,
+                      sourceServiceId, readStatus, isViewOnce, isErased, expireTimer, expires_at
+               FROM messages"""
+    for (message_id, conversation_id, message_type, body, sent_at, received_at,
+         server_ts, source_service_id, read_status, view_once, erased,
+         expire_timer, expires_at) in connection.execute(query):
+
+        media_refs, names = [], []
+        for path, local_key, size, content_type, file_name, plain_hash in attachments.get(message_id, []):
+            plaintext, _authenticated, _matched = signal_desktop.decrypt_attachment(
+                root, path, local_key, size, verify_hash=plain_hash)
+            if not plaintext:
+                continue
+            name = file_name or os.path.basename(path)
+            names.append(name)
+            extension = (content_type or "").split("/")[-1] if "/" in (content_type or "") else None
+            reference = check_in_embedded_media(
+                path, plaintext, name, force_type=content_type or None,
+                force_extension=extension)
+            if reference:
+                media_refs.append(reference)
+
+        if message_type == "outgoing":
+            sender = "Local user"
+        else:
+            sender = by_service.get((source_service_id or "").lower()) or _sender(
+                labels, self_ids, message_type, source_service_id, conversation_id)
+
+        # Only real messages carry a direction. Rows such as a key change or a
+        # profile change are events Signal records in the conversation, and
+        # calling those incoming would overstate what the record shows.
+        if message_type == "outgoing":
+            direction = "Outgoing"
+        elif message_type == "incoming":
+            direction = "Incoming"
+        else:
+            direction = ""
+
+        data_list.append((
+            signal_desktop.js_ms_to_datetime(sent_at),
+            direction,
+            sender,
+            labels.get(conversation_id, conversation_id or ""),
+            body or "",
+            media_refs,
+            ", ".join(names),
+            message_type or "",
+            signal_desktop.js_ms_to_datetime(received_at),
+            signal_desktop.js_ms_to_datetime(server_ts),
+            read_status if read_status is not None else "",
+            "Yes" if view_once else "",
+            "Yes" if erased else "",
+            expire_timer if expire_timer else "",
+            signal_desktop.js_ms_to_datetime(expires_at),
+            conversation_id or "",
+            message_id or "",
+            context.get_relative_path(next(iter(signal_desktop.database_files(files_found)), "")),
+        ))
+
+    connection.close()
+    data_list.sort(key=lambda row: (row[15], row[0] if isinstance(row[0], datetime) else _EPOCH_MIN))
+    with_media = sum(1 for row in data_list if row[5])
+    logfunc(f"Signal Messages: {len(data_list)} message(s) across {len(labels)} conversation(s); "
+            f"{with_media} carry a recovered attachment.")
+    return data_headers, data_list, next(iter(signal_desktop.database_files(files_found)), "")
+
+
+@artifact_processor
+def signalAttachments(context):
+    data_headers = (
+        ("Sent", "datetime"), "Conversation", "Filename", ("File", "media"),
+        "Content Type", "Size (bytes)", "Dimensions", "Duration (s)", "Verified",
+        "View Once", "Stored Path", "SHA-256 Of Original", "Message ID",
+        "Conversation ID", "Source File",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    connection, note = signal_desktop.open_database(files_found, log=logfunc)
+    if connection is None:
+        signal_desktop.explain(note, logfunc)
+        return data_headers, [], ""
+
+    labels = signal_desktop.conversation_labels(connection)
+    root = signal_desktop.attachments_root(files_found)
+    if not root:
+        logfunc("Signal Attachments: the extraction has no attachments.noindex folder, "
+                "so only the database's record of each file is reported.")
+
+    data_list = []
+    query = """SELECT messageId, conversationId, sentAt, path, localKey, size, contentType,
+                      fileName, plaintextHash, width, height, duration, isViewOnce
+               FROM message_attachments WHERE path IS NOT NULL"""
+    for (message_id, conversation_id, sent_at, path, local_key, size, content_type,
+         file_name, plain_hash, width, height, duration, view_once) in connection.execute(query):
+
+        plaintext, authenticated, matched = signal_desktop.decrypt_attachment(
+            root, path, local_key, size, verify_hash=plain_hash)
+        reference = None
+        if plaintext:
+            name = file_name or os.path.basename(path)
+            extension = (content_type or "").split("/")[-1] if "/" in (content_type or "") else None
+            reference = check_in_embedded_media(
+                path, plaintext, name, force_type=content_type or None,
+                force_extension=extension)
+
+        if plaintext is None:
+            verified = "File not in extraction"
+        elif matched is True:
+            verified = "Yes, SHA-256 matched"
+        elif matched is False:
+            verified = "No, SHA-256 differed"
+        else:
+            verified = "Authenticated" if authenticated else "Not authenticated"
+
+        data_list.append((
+            signal_desktop.js_ms_to_datetime(sent_at),
+            labels.get(conversation_id, conversation_id or ""),
+            file_name or "",
+            reference,
+            content_type or "",
+            size if size else "",
+            f"{width}x{height}" if width and height else "",
+            duration if duration else "",
+            verified,
+            "Yes" if view_once else "",
+            path or "",
+            plain_hash or "",
+            message_id or "",
+            conversation_id or "",
+            context.get_relative_path(next(iter(signal_desktop.database_files(files_found)), "")),
+        ))
+
+    connection.close()
+    data_list.sort(key=lambda row: row[0] if isinstance(row[0], datetime) else _EPOCH_MIN)
+    recovered = sum(1 for row in data_list if row[3])
+    logfunc(f"Signal Attachments: {len(data_list)} attachment(s), {recovered} decrypted.")
+    return data_headers, data_list, next(iter(signal_desktop.database_files(files_found)), "")
+
+
+@artifact_processor
+def signalReactions(context):
+    data_headers = (
+        ("Reacted", "datetime"), "Emoji", "From", "Conversation",
+        ("Target Message Sent", "datetime"), "Target Author", "Unread",
+        "Message ID", "Conversation ID", "Source File",
+    )
+
+    files_found = [str(f) for f in context.get_files_found()]
+    connection, note = signal_desktop.open_database(files_found, log=logfunc)
+    if connection is None:
+        signal_desktop.explain(note, logfunc)
+        return data_headers, [], ""
+
+    labels = signal_desktop.conversation_labels(connection)
+    by_service = _service_id_labels(connection, labels)
+
+    data_list = []
+    query = """SELECT emoji, fromId, conversationId, targetAuthorAci, targetTimestamp,
+                      messageReceivedAt, unread, messageId, timestamp
+               FROM reactions"""
+    for (emoji, from_id, conversation_id, target_author, target_ts,
+         received_at, unread, message_id, timestamp) in connection.execute(query):
+        data_list.append((
+            signal_desktop.js_ms_to_datetime(timestamp or received_at),
+            emoji or "",
+            by_service.get((from_id or "").lower()) or labels.get(from_id, from_id or ""),
+            labels.get(conversation_id, conversation_id or ""),
+            signal_desktop.js_ms_to_datetime(target_ts),
+            by_service.get((target_author or "").lower()) or (target_author or ""),
+            "Yes" if unread else "",
+            message_id or "",
+            conversation_id or "",
+            context.get_relative_path(next(iter(signal_desktop.database_files(files_found)), "")),
+        ))
+
+    connection.close()
+    data_list.sort(key=lambda row: row[0] if isinstance(row[0], datetime) else _EPOCH_MIN)
+    logfunc(f"Signal Reactions: {len(data_list)} reaction(s).")
+    return data_headers, data_list, next(iter(signal_desktop.database_files(files_found)), "")

--- a/scripts/context.py
+++ b/scripts/context.py
@@ -23,6 +23,7 @@ class Context:
     _files_found = []
     _filename_lookup_map = {}
     _data_folder = None
+    _app_secrets = {}
 
     @staticmethod
     def set_output_params(output_params):
@@ -373,11 +374,39 @@ class Context:
         return full_path
 
     @staticmethod
+    def set_app_secret(name, value):
+        """
+        Stores a secret supplied at invocation for an application that keeps
+        its data encrypted, such as the Signal Desktop database credential.
+
+        Secrets are gathered once when DLEAPP starts, never from inside an
+        artifact: artifacts run in a loop and, in the GUI, off the main thread,
+        so prompting mid-run would stall processing or deadlock the interface.
+
+        Args:
+            name: the application the secret belongs to, for example 'signal'.
+            value: the secret as a string, or None to record that none was given.
+        """
+        if value:
+            Context._app_secrets[name] = value
+
+    @staticmethod
+    def get_app_secret(name):
+        """
+        Returns the secret supplied for an application, or None.
+
+        Args:
+            name: the application the secret belongs to, for example 'signal'.
+        """
+        return Context._app_secrets.get(name)
+
+    @staticmethod
     def clear():
         """
         Resets all context-related class variables to None, effectively
         clearing any stored state or references, except for the device IDs,
-        OS builds, and output parameters which are retained for efficiency.
+        OS builds, output parameters and supplied secrets which are retained
+        for efficiency.
         """
         Context._report_folder = None
         Context._seeker = None

--- a/scripts/lavafuncs.py
+++ b/scripts/lavafuncs.py
@@ -11,6 +11,7 @@ Global Variables:
 
 Functions:
     sanitize_sql_name: Sanitizes strings for use as SQL identifiers.
+    quote_sql_name: Quotes an identifier so reserved words are safe in SQL.
     get_sql_type: Maps Python types to SQL types.
     initialize_lava: Initializes the LAVA data structure and database.
     lava_process_artifact: Processes and stores artifact data.
@@ -64,6 +65,24 @@ def sanitize_sql_name(name):
     if sanitized and not sanitized[0].isalpha() and sanitized[0] != '_':
         sanitized = '_' + sanitized
     return sanitized.lower()
+
+
+def quote_sql_name(name):
+    """
+    Wraps an identifier in double quotes so it is safe to interpolate into SQL.
+
+    sanitize_sql_name() removes the characters SQLite cannot parse, but it cannot stop a
+    header from sanitizing down to a reserved word. A 'From', 'To' or 'Order' column used
+    to emit `CREATE TABLE ... (from TEXT, ...)`, a syntax error that killed the artifact at
+    report time even though the parser itself ran fine. Quoting makes reserved words legal.
+    Any embedded double quote is doubled, per the SQL standard, so the quoting holds.
+    Args:
+        name (str): The identifier to quote.
+    Returns:
+        str: The identifier wrapped in double quotes.
+    """
+
+    return '"' + str(name).replace('"', '""') + '"'
 
 
 def get_sql_type(python_type):
@@ -344,17 +363,17 @@ def lava_create_sqlite_table(table_name, data):
             original_name, data_type = item[:2]  # Only take the first two elements as media item can have more
             sanitized_name = sanitize_sql_name(original_name)
             sql_type = get_sql_type(data_type)
-            columns.append(f"{sanitized_name} {sql_type}")
+            columns.append(f"{quote_sql_name(sanitized_name)} {sql_type}")
             object_columns[sanitized_name] = data_type
         else:
             original_name = item
             sanitized_name = sanitize_sql_name(original_name)
-            columns.append(f"{sanitized_name} TEXT")
+            columns.append(f"{quote_sql_name(sanitized_name)} TEXT")
 
         column_map[sanitized_name] = original_name
 
     columns_sql = ', '.join(columns)
-    cursor.execute(f"CREATE TABLE IF NOT EXISTS {sanitized_table_name} ({columns_sql})")
+    cursor.execute(f"CREATE TABLE IF NOT EXISTS {quote_sql_name(sanitized_table_name)} ({columns_sql})")
     lava_db.commit()
 
     return sanitized_table_name, column_map, object_columns
@@ -390,7 +409,8 @@ def lava_insert_sqlite_data(table_name, data, object_columns, headers, column_ma
 
     # Prepare the SQL query
     placeholders = ', '.join(['?' for _ in sanitized_columns])
-    query = f"INSERT INTO {table_name} ({', '.join(sanitized_columns)}) VALUES ({placeholders})"
+    quoted_columns = ', '.join(quote_sql_name(column) for column in sanitized_columns)
+    query = f"INSERT INTO {quote_sql_name(table_name)} ({quoted_columns}) VALUES ({placeholders})"
 
     # Prepare the data for insertion
     rows_to_insert = []

--- a/scripts/signal_desktop.py
+++ b/scripts/signal_desktop.py
@@ -156,11 +156,22 @@ def resolve_database_key(files_found, log=None):
     configs = list(config_files(files_found))
     secrets = list(_supplied_secrets(files_found))
 
+    # A secret given at invocation, with --signal-key or the GUI field, comes
+    # first: it is the examiner's explicit choice for this run.
+    try:
+        from scripts.context import Context
+        supplied = Context.get_app_secret("signal")
+    except Exception:
+        supplied = None
+    if supplied:
+        secrets.insert(0, ("--signal-key", supplied))
+
     # 1. A raw key handed to us directly needs nothing else.
     for path, text in secrets:
         if _RAW_KEY_RE.match(text):
-            note(f"Signal Desktop: using the database key supplied in '{os.path.basename(path)}'.")
-            return text.lower(), f"key supplied in {os.path.basename(path)}"
+            source = path if path == "--signal-key" else os.path.basename(path)
+            note(f"Signal Desktop: using the database key supplied by {source}.")
+            return text.lower(), f"key supplied by {source}"
 
     # 2. Older profiles carry the key in the clear.
     for path in configs:
@@ -192,9 +203,9 @@ def resolve_database_key(files_found, log=None):
         for path, text in secrets:
             key = unwrap_encrypted_key(wrapped, text)
             if key:
-                name = os.path.basename(path)
-                note(f"Signal Desktop: unwrapped encryptedKey with the credential in '{name}'.")
-                return key.lower(), f"encryptedKey unwrapped with the credential in {name}"
+                source = path if path == "--signal-key" else f"'{os.path.basename(path)}'"
+                note(f"Signal Desktop: unwrapped encryptedKey with the credential from {source}.")
+                return key.lower(), f"encryptedKey unwrapped with the credential from {source}"
         return None, ("the supplied credential did not unwrap encryptedKey; it may belong to a "
                       "different profile or host")
 
@@ -202,8 +213,8 @@ def resolve_database_key(files_found, log=None):
         return None, ("config.json holds an encryptedKey, which is wrapped with the OS credential "
                       "store. That credential is not part of the profile, so capture it from the "
                       "host (macOS login Keychain service 'Signal Safe Storage', or Windows "
-                      "Credential Manager) and place it in a file named signal_password.txt "
-                      "beside the extraction")
+                      "Credential Manager) and pass it with --signal-key, the Signal key field in "
+                      "the GUI, or a file named signal_password.txt beside the extraction")
 
     if configs:
         return None, "config.json carries neither a plaintext key nor an encryptedKey"

--- a/scripts/signal_desktop.py
+++ b/scripts/signal_desktop.py
@@ -1,0 +1,237 @@
+"""Shared handling for Signal Desktop's encrypted profile.
+
+Signal Desktop keeps its messages in a SQLCipher database at ``sql/db.sqlite``
+and, on recent versions, encrypts each file in ``attachments.noindex`` as well.
+Everything therefore depends on one database key, and where that key lives has
+changed across releases:
+
+* Older builds wrote the key straight into ``config.json`` as ``key``.
+* Current builds store it as ``encryptedKey``, wrapped with Electron's
+  safeStorage. The wrapping password lives in the OS credential store, which is
+  the macOS login Keychain (service ``Signal Safe Storage``) or the Windows
+  Credential Manager, and never in the profile folder.
+
+An extraction of the profile alone therefore cannot be decrypted: the credential
+has to be captured from the running host and supplied alongside. This module
+resolves whichever of those inputs is present, in that order, and reports which
+one it used so the report records how the database was opened.
+
+The unwrap follows Chromium's safeStorage scheme, which Signal inherits from
+Electron::
+
+    KEK  = PBKDF2-HMAC-SHA1(credential, salt="saltysalt", 1003 iterations, 16 bytes)
+    key  = AES-128-CBC-decrypt(KEK, iv=b" " * 16, encryptedKey without its "v10" prefix)
+
+The result is the 64 character hex string Signal passes to
+``PRAGMA key = "x'...'"``.
+"""
+
+import json
+import os
+import re
+
+_SAFE_STORAGE_PREFIX = b"v10"
+_SAFE_STORAGE_SALT = b"saltysalt"
+_SAFE_STORAGE_ITERATIONS = 1003
+_SAFE_STORAGE_KEY_LENGTH = 16
+_SAFE_STORAGE_IV = b" " * 16
+
+# Signal writes a 32 byte key, so the hex form is 64 characters.
+_RAW_KEY_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+
+# Filenames an examiner may drop beside the extraction carrying either the OS
+# credential or an already unwrapped database key. Content decides which it is,
+# so the same names work for both and a mislabelled file still resolves.
+CREDENTIAL_FILENAMES = (
+    "signal-keychain.txt",
+    "signal_keychain.txt",
+    "signal_password.txt",
+    "signal-password.txt",
+    "signal_safe_storage.txt",
+    "signal-safe-storage.txt",
+    "signal_db_key.txt",
+    "signal-db-key.txt",
+)
+
+# SQLCipher 4 defaults, which is what Signal Desktop uses.
+PAGE_SIZE = 4096
+HMAC_ALGORITHM = "sha512"
+KDF_ALGORITHM = "sha512"
+
+
+def crypto_available():
+    try:
+        import Crypto.Cipher.AES  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def unwrap_encrypted_key(encrypted_key_hex, credential):
+    """Unwrap a safeStorage-wrapped Signal database key.
+
+    Args:
+        encrypted_key_hex: the ``encryptedKey`` value from config.json.
+        credential: the OS credential store password, as a string.
+
+    Returns:
+        The database key as a hex string, or None if the input does not unwrap.
+    """
+    from Crypto.Cipher import AES
+    from Crypto.Hash import SHA1
+    from Crypto.Protocol.KDF import PBKDF2
+
+    try:
+        blob = bytes.fromhex(encrypted_key_hex)
+    except (TypeError, ValueError):
+        return None
+    if not blob.startswith(_SAFE_STORAGE_PREFIX):
+        return None
+    blob = blob[len(_SAFE_STORAGE_PREFIX):]
+    if not blob or len(blob) % 16:
+        return None
+
+    kek = PBKDF2(credential, _SAFE_STORAGE_SALT, dkLen=_SAFE_STORAGE_KEY_LENGTH,
+                 count=_SAFE_STORAGE_ITERATIONS, hmac_hash_module=SHA1)
+    plaintext = AES.new(kek, AES.MODE_CBC, _SAFE_STORAGE_IV).decrypt(blob)
+
+    # Strip PKCS#7 padding ourselves: a wrong credential usually yields an
+    # invalid pad, and that is a cleaner signal than an exception.
+    pad = plaintext[-1] if plaintext else 0
+    if not 1 <= pad <= 16 or plaintext[-pad:] != bytes([pad]) * pad:
+        return None
+    candidate = plaintext[:-pad].decode("ascii", "ignore").strip()
+    return candidate if _RAW_KEY_RE.match(candidate) else None
+
+
+def _read_text(path, limit=4096):
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            return handle.read(limit).strip()
+    except OSError:
+        return ""
+
+
+def _supplied_secrets(files_found):
+    """Yield (path, text) for examiner-supplied credential or key files."""
+    for file_found in files_found:
+        file_found = str(file_found)
+        if os.path.basename(file_found).lower() in CREDENTIAL_FILENAMES:
+            text = _read_text(file_found)
+            if text:
+                yield file_found, text
+
+
+def config_files(files_found):
+    for file_found in files_found:
+        file_found = str(file_found)
+        if os.path.basename(file_found) == "config.json":
+            yield file_found
+
+
+def database_files(files_found):
+    """Signal's main database, ignoring its -wal and -shm siblings."""
+    seen = set()
+    for file_found in files_found:
+        file_found = str(file_found)
+        if os.path.basename(file_found) != "db.sqlite":
+            continue
+        real = os.path.realpath(file_found)
+        if real not in seen:
+            seen.add(real)
+            yield file_found
+
+
+def resolve_database_key(files_found, log=None):
+    """Work out the SQLCipher key for a Signal Desktop profile.
+
+    Returns (key_hex, how) where ``how`` describes the source, or (None, reason)
+    when no key could be produced. The reason is written for an examiner reading
+    the report, not for a developer.
+    """
+    def note(message):
+        if log:
+            log(message)
+
+    configs = list(config_files(files_found))
+    secrets = list(_supplied_secrets(files_found))
+
+    # 1. A raw key handed to us directly needs nothing else.
+    for path, text in secrets:
+        if _RAW_KEY_RE.match(text):
+            note(f"Signal Desktop: using the database key supplied in '{os.path.basename(path)}'.")
+            return text.lower(), f"key supplied in {os.path.basename(path)}"
+
+    # 2. Older profiles carry the key in the clear.
+    for path in configs:
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as handle:
+                config = json.load(handle)
+        except (OSError, ValueError):
+            continue
+        plain = config.get("key")
+        if isinstance(plain, str) and _RAW_KEY_RE.match(plain.strip()):
+            note("Signal Desktop: config.json holds the database key in the clear.")
+            return plain.strip().lower(), "plaintext key in config.json"
+
+    # 3. Current profiles need the OS credential to unwrap encryptedKey.
+    wrapped = None
+    for path in configs:
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as handle:
+                config = json.load(handle)
+        except (OSError, ValueError):
+            continue
+        if isinstance(config.get("encryptedKey"), str):
+            wrapped = config["encryptedKey"]
+            break
+
+    if wrapped and secrets:
+        if not crypto_available():
+            return None, "PyCryptodome is not installed, so encryptedKey cannot be unwrapped"
+        for path, text in secrets:
+            key = unwrap_encrypted_key(wrapped, text)
+            if key:
+                name = os.path.basename(path)
+                note(f"Signal Desktop: unwrapped encryptedKey with the credential in '{name}'.")
+                return key.lower(), f"encryptedKey unwrapped with the credential in {name}"
+        return None, ("the supplied credential did not unwrap encryptedKey; it may belong to a "
+                      "different profile or host")
+
+    if wrapped:
+        return None, ("config.json holds an encryptedKey, which is wrapped with the OS credential "
+                      "store. That credential is not part of the profile, so capture it from the "
+                      "host (macOS login Keychain service 'Signal Safe Storage', or Windows "
+                      "Credential Manager) and place it in a file named signal_password.txt "
+                      "beside the extraction")
+
+    if configs:
+        return None, "config.json carries neither a plaintext key nor an encryptedKey"
+    return None, "no Signal Desktop config.json was found"
+
+
+def decrypt_database(database_path, key_hex, output_path, log=None):
+    """Decrypt db.sqlite to a plaintext copy. Returns the path or None."""
+    from scripts.sqlcipher_decrypt import decrypt_sqlcipher_db
+
+    try:
+        pages, verified = decrypt_sqlcipher_db(
+            database_path, key_hex, output_path,
+            page_size=PAGE_SIZE, hmac_algorithm=HMAC_ALGORITHM,
+            kdf_algorithm=KDF_ALGORITHM, raw_key=True, apply_wal=True)
+    except Exception as ex:  # a malformed image should not stop the module
+        if log:
+            log(f"Signal Desktop: could not decrypt '{database_path}': {ex}")
+        return None
+    if not pages:
+        if log:
+            log(f"Signal Desktop: '{database_path}' is too small to be a database.")
+        return None
+    if not verified:
+        if log:
+            log("Signal Desktop: the key did not authenticate any page of the database. "
+                "It belongs to a different profile, or the file is damaged.")
+        return None
+    if log:
+        log(f"Signal Desktop: decrypted {pages} page(s), {verified} authenticated.")
+    return output_path

--- a/scripts/signal_desktop.py
+++ b/scripts/signal_desktop.py
@@ -26,9 +26,15 @@ The result is the 64 character hex string Signal passes to
 ``PRAGMA key = "x'...'"``.
 """
 
+import base64
+import hashlib
+import hmac
 import json
 import os
 import re
+import sqlite3
+import tempfile
+from datetime import datetime, timezone
 
 _SAFE_STORAGE_PREFIX = b"v10"
 _SAFE_STORAGE_SALT = b"saltysalt"
@@ -219,6 +225,172 @@ def resolve_database_key(files_found, log=None):
     if configs:
         return None, "config.json carries neither a plaintext key nor an encryptedKey"
     return None, "no Signal Desktop config.json was found"
+
+
+def js_ms_to_datetime(value):
+    """Convert a JavaScript millisecond timestamp to an aware UTC datetime."""
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        return ""
+    if value <= 0:
+        return ""
+    try:
+        return datetime.fromtimestamp(value / 1000, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return ""
+
+
+def attachments_root(files_found):
+    """Locate the attachments.noindex folder within the extraction."""
+    for file_found in files_found:
+        parts = str(file_found).replace("\\", "/").split("/")
+        if "attachments.noindex" in parts:
+            index = parts.index("attachments.noindex")
+            return "/".join(parts[:index + 1])
+    return None
+
+
+def decrypt_attachment(root, relative_path, local_key, size, verify_hash=None):
+    """Decrypt one file from attachments.noindex.
+
+    Signal encrypts each stored attachment with a key held in the database, so
+    the files are unreadable on their own. The layout is::
+
+        IV (16) || AES-256-CBC ciphertext || HMAC-SHA256 (32)
+
+    where the base64 ``localKey`` is 64 bytes: the AES key followed by the MAC
+    key. The plaintext is then padded with zeroes to hide its true length, so
+    the real file is the first ``size`` bytes.
+
+    Returns (plaintext, authenticated, hash_matches). ``plaintext`` is None when
+    the file is missing or too short to be an attachment.
+    """
+    if not root or not relative_path or not local_key:
+        return None, False, None
+    full_path = os.path.join(root, relative_path.replace("/", os.sep))
+    try:
+        with open(full_path, "rb") as handle:
+            blob = handle.read()
+    except OSError:
+        return None, False, None
+    if len(blob) <= 48:
+        return None, False, None
+
+    try:
+        keys = base64.b64decode(local_key)
+    except (ValueError, TypeError):
+        return None, False, None
+    if len(keys) < 64:
+        return None, False, None
+
+    from Crypto.Cipher import AES
+
+    iv, ciphertext, stored_mac = blob[:16], blob[16:-32], blob[-32:]
+    calculated = hmac.new(keys[32:64], blob[:-32], hashlib.sha256).digest()
+    authenticated = hmac.compare_digest(calculated, stored_mac)
+    try:
+        plaintext = AES.new(keys[:32], AES.MODE_CBC, iv).decrypt(ciphertext)
+    except ValueError:
+        return None, authenticated, None
+
+    pad = plaintext[-1] if plaintext else 0
+    if 1 <= pad <= 16 and plaintext[-pad:] == bytes([pad]) * pad:
+        plaintext = plaintext[:-pad]
+    if size and 0 < size <= len(plaintext):
+        plaintext = plaintext[:size]
+
+    hash_matches = None
+    if verify_hash:
+        hash_matches = hashlib.sha256(plaintext).hexdigest() == verify_hash
+    return plaintext, authenticated, hash_matches
+
+
+def conversation_labels(connection):
+    """Map conversation id to the best available human-readable name."""
+    labels = {}
+    try:
+        rows = connection.execute(
+            "SELECT id, type, name, profileFullName, profileName, e164 FROM conversations")
+    except sqlite3.Error:
+        return labels
+    for cid, ctype, name, full, profile, e164 in rows:
+        label = name or full or profile or e164 or cid
+        if ctype == "group" and name:
+            label = f"{name} (group)"
+        labels[cid] = label
+    return labels
+
+
+def self_service_ids(connection):
+    """The local account's own service ids, used to mark outgoing messages."""
+    ids = set()
+    try:
+        rows = connection.execute("SELECT id, json FROM items WHERE id IN ('uuid_id','pni')")
+    except sqlite3.Error:
+        return ids
+    for _key, blob in rows:
+        try:
+            value = json.loads(blob).get("value")
+        except (ValueError, TypeError):
+            continue
+        if isinstance(value, str):
+            ids.add(value.split(".")[0].replace("PNI:", "").lower())
+    return ids
+
+
+# Cache of source database path -> decrypted copy, so several artifacts sharing
+# one profile decrypt it once per run.
+_decrypted_cache = {}
+
+# Every Signal artifact hits the same missing credential, and repeating the full
+# explanation once per artifact buries the rest of the log. Say it once.
+_explained = set()
+
+
+def explain(reason, log):
+    """Log the long form of a failure the first time, a short form after."""
+    if not log:
+        return
+    if reason in _explained:
+        log("Signal Desktop: still no database credential, see above.")
+    else:
+        _explained.add(reason)
+        log(f"Signal Desktop: {reason}.")
+
+
+def open_database(files_found, log=None):
+    """Decrypt and open the Signal database. Returns (connection, note).
+
+    The connection is None when the database could not be opened, and the note
+    then explains why in terms an examiner can act on.
+    """
+    databases = list(database_files(files_found))
+    if not databases:
+        return None, "no Signal Desktop database (sql/db.sqlite) was found"
+
+    database_path = databases[0]
+    cached = _decrypted_cache.get(os.path.realpath(database_path))
+    if cached:
+        try:
+            return sqlite3.connect(f"file:{cached}?mode=ro", uri=True), "decrypted earlier this run"
+        except sqlite3.Error:
+            pass
+
+    key_hex, how = resolve_database_key(files_found, log=log)
+    if not key_hex:
+        return None, how
+
+    digest = hashlib.sha1(database_path.encode("utf-8", "replace")).hexdigest()[:12]
+    output_path = os.path.join(tempfile.gettempdir(), "dleapp_signal", f"signal_{digest}.db")
+    if not decrypt_database(database_path, key_hex, output_path, log=log):
+        return None, "the database did not decrypt with the key that was resolved"
+
+    _decrypted_cache[os.path.realpath(database_path)] = output_path
+    try:
+        return sqlite3.connect(f"file:{output_path}?mode=ro", uri=True), how
+    except sqlite3.Error as ex:
+        return None, f"the decrypted database could not be opened: {ex}"
 
 
 def decrypt_database(database_path, key_hex, output_path, log=None):

--- a/scripts/sqlcipher_decrypt.py
+++ b/scripts/sqlcipher_decrypt.py
@@ -1,0 +1,173 @@
+"""Minimal pure-python SQLCipher reader.
+
+Implemented with PyCryptodome (already a DLEAPP requirement) rather than a
+native SQLCipher build, so packaged/frozen DLEAPP builds keep working without
+an extra binary dependency.
+
+Only the subset needed to read an encrypted database is implemented: the file
+is decrypted to a plaintext copy which callers open with the stdlib sqlite3.
+"""
+import hashlib
+import hmac
+import os
+import struct
+
+from Crypto.Cipher import AES
+
+DEFAULT_PAGE_SIZE = 4096
+IV_LENGTH = 16
+FAST_KDF_ITER = 2  # SQLCipher's iteration count for the HMAC subkey
+
+HMAC_LENGTHS = {'sha1': 20, 'sha256': 32, 'sha512': 64}
+
+WAL_HEADER_SIZE = 32
+WAL_FRAME_HEADER_SIZE = 24
+WAL_MAGIC = (0x377F0682, 0x377F0683)
+
+
+def _reserve_size(hmac_length):
+    """Bytes reserved at the end of each page: IV + HMAC, padded to an AES block."""
+    return ((IV_LENGTH + hmac_length + 15) // 16) * 16
+
+
+def _decrypt_page(page, page_number, encryption_key, hmac_key, digest, hmac_length, reserve,
+                  page_size, plaintext_header_size=0):
+    """Decrypt one SQLCipher page. Returns (plaintext_body, hmac_verified)."""
+    # Page 1 starts after whatever is stored in the clear: either the salt, or a
+    # plaintext header when the database keeps one
+    body_start = (plaintext_header_size or 16) if page_number == 1 else 0
+    body_end = page_size - reserve
+    iv = page[body_end:body_end + IV_LENGTH]
+    stored_hmac = page[body_end + IV_LENGTH:body_end + IV_LENGTH + hmac_length]
+    calculated = hmac.new(hmac_key,
+                          page[body_start:body_end + IV_LENGTH]
+                          + page_number.to_bytes(4, 'little'),
+                          digest).digest()
+    body = AES.new(encryption_key, AES.MODE_CBC, iv).decrypt(page[body_start:body_end])
+    if page_number == 1:
+        # Restore the bytes that were never encrypted
+        body = (page[:plaintext_header_size] if plaintext_header_size
+                else b'SQLite format 3\x00') + body
+    return body + b'\x00' * reserve, hmac.compare_digest(calculated, stored_hmac)
+
+
+def _wal_pages(wal_path, page_size):
+    """Yield (page_number, raw_encrypted_page) for the committed frames of a SQLCipher WAL.
+
+    SQLCipher leaves the WAL and frame headers readable and encrypts only the page
+    payloads, so frames can be located without the key. Later frames supersede
+    earlier ones for the same page; anything after the final commit frame is an
+    incomplete transaction and is ignored.
+    """
+    with open(wal_path, 'rb') as wal_file:
+        wal = wal_file.read()
+    if len(wal) < WAL_HEADER_SIZE:
+        return {}, 0
+    if struct.unpack('>I', wal[0:4])[0] not in WAL_MAGIC:
+        return {}, 0
+
+    header_salts = wal[16:24]
+    frame_size = WAL_FRAME_HEADER_SIZE + page_size
+    frame_count = (len(wal) - WAL_HEADER_SIZE) // frame_size
+
+    latest = {}
+    committed = {}
+    database_pages = 0
+    for index in range(frame_count):
+        offset = WAL_HEADER_SIZE + index * frame_size
+        frame_header = wal[offset:offset + WAL_FRAME_HEADER_SIZE]
+        if frame_header[8:16] != header_salts:
+            continue  # frame belongs to an earlier WAL generation
+        page_number = struct.unpack('>I', frame_header[0:4])[0]
+        commit_size = struct.unpack('>I', frame_header[4:8])[0]
+        latest[page_number] = wal[offset + WAL_FRAME_HEADER_SIZE:offset + frame_size]
+        if commit_size:
+            # Transaction boundary: everything seen so far is durable
+            committed = dict(latest)
+            database_pages = commit_size
+    return committed, database_pages
+
+
+def decrypt_sqlcipher_db(encrypted_path, passphrase, output_path, page_size=DEFAULT_PAGE_SIZE,
+                         kdf_iterations=1, hmac_algorithm='sha1', kdf_algorithm='sha1',
+                         raw_key=False, apply_wal=True, plaintext_header_size=0,
+                         external_salt=None):
+    """Decrypt a SQLCipher database to a plaintext SQLite file.
+
+    Args:
+        encrypted_path: path to the encrypted database.
+        passphrase: passphrase string, or hex string when raw_key is True.
+        output_path: where the decrypted database is written.
+        page_size: SQLCipher page size.
+        kdf_iterations: PBKDF2 iterations for the encryption key. Signal uses 1
+            because its key is already random.
+        hmac_algorithm: 'sha1', 'sha256' or 'sha512'.
+        kdf_algorithm: PBKDF2 hash, usually matching hmac_algorithm.
+        raw_key: treat passphrase as a hex-encoded key used directly (PRAGMA
+            key = "x'..'") instead of deriving it.
+        apply_wal: replay a sibling '-wal' file over the database image. Without
+            this, recent records that have not been checkpointed are missed.
+        plaintext_header_size: bytes at the start of the file left unencrypted.
+            Apps that need the file to stay recognisable as SQLite set this,
+            usually to 32.
+        external_salt: the 16 byte salt, when it is not stored in the file. A
+            non-zero plaintext header displaces the salt, so it is kept with the
+            key instead (Signal for iOS stores both together in the keychain).
+
+    Returns:
+        (pages_decrypted, pages_whose_hmac_verified), counting replayed WAL frames
+        as well as main-image pages. Equal values mean everything authenticated;
+        0 verified means the passphrase or settings are wrong.
+    """
+    hmac_length = HMAC_LENGTHS[hmac_algorithm]
+    reserve = _reserve_size(hmac_length)
+
+    with open(encrypted_path, 'rb') as encrypted_file:
+        raw = encrypted_file.read()
+    if len(raw) < page_size:
+        return 0, 0
+
+    salt = external_salt if external_salt else raw[:16]
+    if raw_key:
+        encryption_key = passphrase if isinstance(passphrase, (bytes, bytearray)) \
+            else bytes.fromhex(passphrase)
+    else:
+        encryption_key = hashlib.pbkdf2_hmac(kdf_algorithm, passphrase.encode(), salt,
+                                             kdf_iterations, 32)
+    hmac_key = hashlib.pbkdf2_hmac(kdf_algorithm, encryption_key,
+                                   bytes(byte ^ 0x3A for byte in salt), FAST_KDF_ITER, 32)
+
+    digest = getattr(hashlib, hmac_algorithm)
+    decrypted_pages = verified = 0
+
+    pages = []
+    for page_index in range(len(raw) // page_size):
+        body, page_ok = _decrypt_page(raw[page_index * page_size:(page_index + 1) * page_size],
+                                      page_index + 1, encryption_key, hmac_key, digest,
+                                      hmac_length, reserve, page_size, plaintext_header_size)
+        pages.append(body)
+        decrypted_pages += 1
+        verified += page_ok
+
+    # Recent activity often lives only in the write-ahead log, so replay it over
+    # the main database image before handing the file to sqlite3
+    if apply_wal:
+        wal_path = encrypted_path + '-wal'
+        if os.path.exists(wal_path):
+            wal_pages, database_pages = _wal_pages(wal_path, page_size)
+            for page_number, encrypted_page in sorted(wal_pages.items()):
+                body, page_ok = _decrypt_page(encrypted_page, page_number, encryption_key,
+                                              hmac_key, digest, hmac_length, reserve, page_size,
+                                              plaintext_header_size)
+                while len(pages) < page_number:
+                    pages.append(b'\x00' * page_size)
+                pages[page_number - 1] = body
+                decrypted_pages += 1
+                verified += page_ok
+            if database_pages:
+                pages = pages[:database_pages]
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, 'wb') as output_file:
+        output_file.write(b''.join(pages))
+    return decrypted_pages, verified


### PR DESCRIPTION
Signal encrypts its message database with SQLCipher and encrypts every file in `attachments.noindex` with a key held inside that database, so a profile yields nothing without the credential. With one supplied, all of it opens.

## Artifacts

Messages (LAVA conversation view, attachment images inline) · Attachments · Conversations · Calls · Reactions · Sessions & Identity Keys · Account & Application.

## Getting the key

The database key is wrapped with Electron safeStorage, so it lives in the OS credential store rather than the profile: the macOS Keychain item `Signal Safe Storage`, or the Windows Credential Manager. The unwrap is Chromium's scheme, PBKDF2-HMAC-SHA1 over `saltysalt` for 1003 iterations then AES-128-CBC with a space-filled IV, confirmed against [mfm-mf/signal-forensics](https://github.com/mfm-mf/signal-forensics). Older profiles that still hold a plaintext `key` in `config.json`, as [John Ball's article](https://www.johndball.com/pulling-encrypted-signal-messages-off-of-desktop-os-for-forensics/) describes, need nothing at all.

Secrets are gathered at invocation, never from inside an artifact — modules run in a loop and, under the GUI, off the main thread, so a prompt there would stall the run or deadlock the interface:

```
--signal-key VALUE   the credential or the 64 character key
--signal-key FILE    a file holding either
--signal-key         prompt without echo, keeping it out of shell history
```

plus a masked GUI field, and a `signal_password.txt` beside the extraction for batch runs.

`scripts/sqlcipher_decrypt.py` is the pure-python reader ALEAPP and iLEAPP already use, vendored unchanged apart from the tool name so a fix in one can be copied across.

## Attachments

Each stored file is `IV || AES-256-CBC || HMAC-SHA256`, keyed by the 64 byte base64 `localKey` the database holds per attachment. Signal then pads the plaintext with zeroes to hide its true length, so the file is truncated to the recorded size. Every recovered file is checked against its MAC and, where the database kept one, its SHA-256.

## Two fixes this exposed

**lavafuncs never quoted SQL identifiers.** A column sanitising down to a reserved word emitted `CREATE TABLE (from TEXT, ...)` and killed the artifact at report time, with the parse itself having succeeded — a Reactions column named `From` hit it. `quote_sql_name` is ported verbatim from iLEAPP, which already carries this fix, and applied at all four interpolation sites. This was a latent bug affecting any artifact in this repo, not just Signal.

**System events were labelled Incoming.** Key changes and profile changes are not received messages. Only real messages carry a direction now; events report their type and leave direction empty.

## Verification

Against a live macOS profile, and again through `-t zip` with identical counts:

- 12,226 of 12,226 database pages authenticated
- 3,837 messages across 173 conversations — 2,016 incoming, 1,662 outgoing, 159 events
- 297 of 297 attachments decrypted: 295 SHA-256 verified, 2 authenticated where no hash was recorded
- 15 calls, 390 reactions, 165 session and identity key records

With no credential, every artifact explains what to capture and where, once rather than once per artifact, and Signal Account & Application still reports what the unencrypted profile files hold. The Discord corpus was re-run through the validator afterwards to confirm the lavafuncs change regressed nothing.

Key material is never printed. The account artifact reports the presence of the password, master key, profile key and storage keys, since those would allow impersonation.

No corpus data is included here: the sample is personal account data held privately.