### PR TITLE
Parse a Signal database that was already decrypted

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ field. A file named `signal_password.txt` beside the extraction is also picked
 up, which suits batch runs. Older profiles that still hold a plaintext `key` in
 `config.json` need nothing at all.
 
-Without a credential the Signal artifacts report why and produce no rows, rather
-than failing silently. `scripts/sqlcipher_decrypt.py` is the same pure-python
+If the database was already decrypted, with DB Browser for SQLCipher or another
+tool, DLEAPP detects that and parses it as it is — no credential needed.
+
+Without a credential, and with the database still encrypted, the Signal
+artifacts report why and produce no rows rather than failing silently. `scripts/sqlcipher_decrypt.py` is the same pure-python
 reader ALEAPP and iLEAPP use, so it needs no native SQLCipher build.
 
 If you want to contribute hit me up on twitter: https://twitter.com/AlexisBrignoni   

--- a/scripts/signal_desktop.py
+++ b/scripts/signal_desktop.py
@@ -135,6 +135,23 @@ def config_files(files_found):
             yield file_found
 
 
+_SQLITE_MAGIC = b"SQLite format 3\x00"
+
+
+def is_plaintext_sqlite(path):
+    """True when a file is an unencrypted SQLite database.
+
+    A SQLCipher database has no readable header: its first bytes are the salt.
+    So the magic string is a reliable way to tell a database that still needs a
+    key from one that was decrypted before it reached us.
+    """
+    try:
+        with open(path, "rb") as handle:
+            return handle.read(16) == _SQLITE_MAGIC
+    except OSError:
+        return False
+
+
 def database_files(files_found):
     """Signal's main database, ignoring its -wal and -shm siblings."""
     seen = set()
@@ -349,14 +366,15 @@ _explained = set()
 
 
 def explain(reason, log):
-    """Log the long form of a failure the first time, a short form after."""
-    if not log:
+    """Log a shared condition once, not once per artifact.
+
+    Every Signal artifact opens the same database, so without this each of them
+    repeats the same sentence and buries the rest of the log.
+    """
+    if not log or reason in _explained:
         return
-    if reason in _explained:
-        log("Signal Desktop: still no database credential, see above.")
-    else:
-        _explained.add(reason)
-        log(f"Signal Desktop: {reason}.")
+    _explained.add(reason)
+    log(f"Signal Desktop: {reason}.")
 
 
 def open_database(files_found, log=None):
@@ -376,6 +394,17 @@ def open_database(files_found, log=None):
             return sqlite3.connect(f"file:{cached}?mode=ro", uri=True), "decrypted earlier this run"
         except sqlite3.Error:
             pass
+
+    # An examiner may have decrypted the database already, with DB Browser for
+    # SQLCipher or another tool, and be parsing that copy. It is then a plain
+    # SQLite file and needs no key, so read it as it is rather than refusing.
+    if is_plaintext_sqlite(database_path):
+        explain("the database is already decrypted, so no credential is needed", log)
+        try:
+            return (sqlite3.connect(f"file:{database_path}?mode=ro", uri=True),
+                    "already decrypted before parsing")
+        except sqlite3.Error as ex:
+            return None, f"the decrypted database could not be opened: {ex}"
 
     key_hex, how = resolve_database_key(files_found, log=log)
     if not key_hex:


### PR DESCRIPTION
The published guidance for Signal Desktop forensics — including [John Ball's article](https://www.johndball.com/pulling-encrypted-signal-messages-off-of-desktop-os-for-forensics/) — is to open `db.sqlite` in DB Browser for SQLCipher and work from there. An examiner may therefore arrive with a decrypted database and no credential at all.

DLEAPP refused that case. It always tried to decrypt, and a plain SQLite file has no valid salt or page MAC, so the run reported that the key did not authenticate and produced nothing.

## Change

Detect it. A SQLCipher database starts with its salt and has no readable header, so the `SQLite format 3\0` magic is a reliable way to tell a database that still needs a key from one that does not. When the file is already plain, it is opened directly and no credential is asked for.

Also stop repeating a shared condition once per artifact. All seven Signal artifacts open the same database, so whatever was true of it was being said seven times.

## Verification

Tested with the decrypted copy DLEAPP itself writes, placed in a profile with no credential anywhere. It parsed to exactly the same figures as the encrypted original:

| | Encrypted + credential | Already decrypted |
| --- | --- | --- |
| Messages | 3,837 | 3,837 |
| Attachments | 297 | 297 |
| Reactions | 390 | 390 |
| Conversations | 173 | 173 |
| Calls | 15 | 15 |
| Sessions & Identity Keys | 165 | 165 |

The encrypted no-credential path still prints its guidance, now exactly once instead of seven times.

Note that attachments still decrypt in both cases: their keys live inside the database, so once it is open they are readable either way.