### PR TITLE
CI parity: lint + runtime-contract workflows, admin test suite, path-safe report names

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -1,0 +1,49 @@
+name: Python Lint Check
+
+on:
+  pull_request:
+    paths:
+      - '**.py' # only trigger on python files
+jobs:
+  lint-changed-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Required to fetch the base branch for comparison
+          fetch-depth: 0
+
+      - name: Get changed Python files
+        id: changed-files-py
+        uses: tj-actions/changed-files@v46 # This action finds changed files
+        with:
+          files: |
+            **.py
+
+      - name: Set up Python
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Pylint
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        run: python -m pip install pylint
+
+      - name: Install dependencies
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        run: python -m pip install -r requirements.txt
+
+      # Fails only on warnings this pull request introduces. dleapp.py and
+      # dleappGUI.py carry pre-existing warnings that are structural rather than
+      # fixable -- wildcard imports are how those modules are put together -- so
+      # failing on the absolute count would make every pull request that touches
+      # them red for reasons unrelated to the change. See the script's docstring.
+      - name: Run on changed files
+        if: steps.changed-files-py.outputs.any_changed == 'true'
+        run: |
+          BASE=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+          echo "Comparing against merge base $BASE"
+          python admin/scripts/lint_changed.py --base-ref "$BASE" \
+            ${{ steps.changed-files-py.outputs.all_changed_files }}

--- a/.github/workflows/python_runtime_contract.yml
+++ b/.github/workflows/python_runtime_contract.yml
@@ -1,0 +1,41 @@
+name: Python Runtime Contract
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/python_runtime_contract.yml'
+      - 'README.md'
+      - 'requirements.txt'
+      # The job runs the whole admin/test/scripts suite, so trigger on all of it
+      - 'admin/test/scripts/**'
+      # The suite imports every artifact module, which is the only check that a
+      # change parses on the oldest supported Python. Lint runs on one, newer
+      # version and cannot see this class of break.
+      - 'scripts/**'
+      # The entry points are covered by the same suite and are equally able to
+      # break on an older Python
+      - 'dleapp.py'
+      - 'dleappGUI.py'
+
+jobs:
+  runtime-contract:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install runtime dependencies
+        run: python -m pip install -r requirements.txt
+
+      - name: Run admin compatibility tests
+        run: python -m unittest discover -s admin/test/scripts -p 'test_*.py'

--- a/admin/scripts/lint_changed.py
+++ b/admin/scripts/lint_changed.py
@@ -1,0 +1,119 @@
+"""Fail CI only on pylint warnings a change actually introduces.
+
+The lint job runs pylint over the files a pull request touches. Several long-lived
+modules carry pre-existing warnings that are deliberate rather than fixable --
+`ileapp.py` uses wildcard imports as its module architecture, `scripts/ilapfuncs.py`
+re-exports names it does not itself use so that older artifact modules keep importing
+them. Any pull request that touches one of those files therefore went red for reasons
+that had nothing to do with the change, which pushes contributors toward either
+unrelated refactors or blanket file-level `# pylint: disable` comments. Both are worse
+than the debt.
+
+This script lints the same file set twice, once at the merge base and once at the
+change, and fails only when a (file, warning) pair appears more often than it did
+before. New code is held to the full standard; existing debt neither blocks a pull
+request nor gets silently widened.
+
+Two details matter for a stable comparison, both learned the hard way:
+
+* pylint's results depend on which files are analysed together, because it infers
+  across the set. Both runs therefore lint the same list of paths.
+* pylint caches results between runs and will otherwise report stale data, so both
+  runs pass --persistent=no.
+
+Usage:
+    python admin/scripts/lint_changed.py --base-ref <sha> <file> [<file> ...]
+"""
+
+import argparse
+import collections
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+PYLINT_ARGS = ['--disable=C,R', '--persistent=no', '--output-format=json']
+
+
+def run_pylint(repo_dir, paths):
+    """Return Counter keyed by (path, symbol) for paths that exist in repo_dir."""
+    present = [p for p in paths if os.path.exists(os.path.join(repo_dir, p))]
+    if not present:
+        return collections.Counter()
+
+    env = dict(os.environ, PYTHONPATH='.')
+    result = subprocess.run(
+        [sys.executable, '-m', 'pylint', *present, *PYLINT_ARGS],
+        cwd=repo_dir, env=env, capture_output=True, text=True, check=False)
+
+    stdout = result.stdout.strip()
+    if not stdout:
+        # No JSON at all means pylint failed to start rather than finding nothing.
+        if result.returncode not in (0,):
+            print(f'pylint produced no output (exit {result.returncode}):\n{result.stderr}',
+                  file=sys.stderr)
+            sys.exit(2)
+        return collections.Counter()
+
+    try:
+        messages = json.loads(stdout)
+    except json.JSONDecodeError:
+        print(f'could not parse pylint output:\n{stdout[:2000]}', file=sys.stderr)
+        sys.exit(2)
+
+    return collections.Counter((m['path'], m['symbol']) for m in messages)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--base-ref', required=True,
+                        help='commit to compare against, normally the merge base')
+    parser.add_argument('paths', nargs='*', help='changed Python files')
+    args = parser.parse_args()
+
+    paths = [p for p in args.paths if p.endswith('.py')]
+    if not paths:
+        print('No Python files changed.')
+        return 0
+
+    print('Linting:\n' + '\n'.join(f'  {p}' for p in paths) + '\n')
+    after = run_pylint('.', paths)
+
+    # A detached worktree gives the base revision with full repo context, so pylint
+    # resolves imports there the same way it does for the change.
+    with tempfile.TemporaryDirectory() as tmp:
+        base_dir = os.path.join(tmp, 'base')
+        subprocess.run(['git', 'worktree', 'add', '--detach', '--quiet', base_dir,
+                        args.base_ref], check=True, capture_output=True)
+        try:
+            before = run_pylint(base_dir, paths)
+        finally:
+            subprocess.run(['git', 'worktree', 'remove', '--force', base_dir],
+                           check=False, capture_output=True)
+
+    introduced = {key: count - before.get(key, 0)
+                  for key, count in after.items() if count > before.get(key, 0)}
+
+    total_before, total_after = sum(before.values()), sum(after.values())
+    print(f'pre-existing warnings in these files: {total_before}')
+    print(f'warnings now:                         {total_after}')
+
+    if not introduced:
+        removed = total_before - total_after
+        if removed > 0:
+            print(f'\nNo new warnings introduced ({removed} fewer than before). PASS')
+        else:
+            print('\nNo new warnings introduced. PASS')
+        return 0
+
+    print('\nThis change introduces new pylint warnings:\n')
+    for (path, symbol), count in sorted(introduced.items()):
+        print(f'  {path}: {symbol} (+{count})')
+    print('\nRe-run locally with:')
+    print(f'  PYTHONPATH=. python -m pylint {" ".join(paths)} {" ".join(PYLINT_ARGS[:2])}')
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/admin/test/scripts/test_artifact_imports.py
+++ b/admin/test/scripts/test_artifact_imports.py
@@ -1,0 +1,62 @@
+# pylint: disable=broad-exception-caught
+"""Smoke test: every artifact module must import on the running Python.
+
+Run across the supported Python versions in CI, this is the only check that a
+change still parses and imports on the oldest one. Syntax accepted by a newer
+interpreter is not always accepted by an older one -- a multi-line expression
+inside an f-string, for example, needs 3.12 (PEP 701) -- and lint alone does
+not catch it because lint runs on a single, newer version.
+
+It validates *importability*, not parsing correctness (which needs sample
+data). Modules are loaded by file path -- mirroring scripts/plugin_loader.py
+-- so files with dots in their name load correctly.
+"""
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+ARTIFACTS_DIR = REPO_ROOT / 'scripts' / 'artifacts'
+
+# Floors, not exact counts, so ordinary additions and removals do not fail the
+# build while a collapse in what loads still does.
+MINIMUM_ARTIFACT_MODULES = 12
+MINIMUM_PLUGINS = 30
+
+
+class TestArtifactImports(unittest.TestCase):
+
+    def test_all_artifact_modules_import(self):
+        """Import every scripts/artifacts/*.py and fail on any import error."""
+        failures = []
+        count = 0
+        for py_file in sorted(ARTIFACTS_DIR.glob('*.py')):
+            if py_file.name.startswith('__'):
+                continue
+            try:
+                spec = importlib.util.spec_from_file_location(py_file.stem, py_file)
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                count += 1
+            except Exception as exc:
+                failures.append(f'{py_file.name}: {type(exc).__name__}: {exc}')
+
+        self.assertEqual(failures, [],
+                         f'{len(failures)} artifact import failure(s):\n' + '\n'.join(failures))
+        self.assertGreater(count, MINIMUM_ARTIFACT_MODULES,
+                           f'Only {count} artifact modules imported - did the search path change?')
+
+    def test_plugin_loader_loads(self):
+        """The real PluginLoader must load a healthy number of plugins."""
+        from scripts.plugin_loader import PluginLoader
+        loader = PluginLoader()
+        self.assertGreater(len(loader), MINIMUM_PLUGINS,
+                           f'PluginLoader loaded only {len(loader)} plugins')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/admin/test/scripts/test_entry_points.py
+++ b/admin/test/scripts/test_entry_points.py
@@ -1,0 +1,49 @@
+"""The command line and GUI entry points must load on every supported Python.
+
+The artifact import test covers scripts/, but the entry points themselves sat
+outside any version-matrixed check, so a change to either could break on the
+oldest supported Python and only surface when a user ran it.
+
+The two are checked differently on purpose. dleapp.py guards its startup with
+'if __name__', so it can be imported outright, which catches import-time errors
+as well as syntax. dleappGUI.py builds its window at module level, so importing
+it would need a display that CI does not have; compiling it still catches the
+syntax-level breakage this is chiefly guarding against, such as an f-string
+that only parses on Python 3.12 (PEP 701).
+"""
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+CLI_ENTRY_POINT = REPO_ROOT / 'dleapp.py'
+GUI_ENTRY_POINT = REPO_ROOT / 'dleappGUI.py'
+
+
+class TestEntryPoints(unittest.TestCase):
+
+    def test_cli_entry_point_imports(self):
+        """dleapp.py must import, and expose main()."""
+        self.assertTrue(CLI_ENTRY_POINT.is_file(), f'{CLI_ENTRY_POINT} is missing')
+        spec = importlib.util.spec_from_file_location('entry_point_check', CLI_ENTRY_POINT)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        self.assertTrue(hasattr(module, 'main'), 'dleapp.py no longer exposes main()')
+
+    def test_gui_entry_point_compiles(self):
+        """dleappGUI.py must at least compile; it cannot be imported without a display."""
+        self.assertTrue(GUI_ENTRY_POINT.is_file(), f'{GUI_ENTRY_POINT} is missing')
+        source = GUI_ENTRY_POINT.read_text(encoding='utf-8', errors='replace')
+        try:
+            compile(source, str(GUI_ENTRY_POINT), 'exec')
+        except SyntaxError as error:
+            self.fail(f'dleappGUI.py does not compile on this Python: '
+                      f'line {error.lineno}: {error.msg}')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/admin/test/scripts/test_lava_sql_identifiers.py
+++ b/admin/test/scripts/test_lava_sql_identifiers.py
@@ -1,0 +1,212 @@
+"""Guard the LAVA writer against artifact names that are hostile to SQL or to the filesystem.
+
+The LAVA writer turns each artifact's data_headers into SQLite column names. Those
+identifiers used to be interpolated into CREATE TABLE and INSERT statements unquoted, so
+any header that sanitizes down to a reserved word ('From', 'To', 'Order', ...) killed the
+artifact at report time with `near "from": syntax error`. The parser itself ran fine, so
+the only symptom was a LAVA table that silently never appeared, and
+admin/test/scripts/test_module.py mocks the LAVA database connection, so module-level
+testing passes either way. Module authors hit this three times in one day and worked
+around it by renaming columns.
+
+The same class of trap exists for a '/' in an artifact name or category: those become
+HTML/TSV/KML filenames and _HTML folder names, and os.path.join() reads the '/' as a path
+separator, so the artifact either fails to write its report or lands somewhere unintended.
+"""
+import datetime
+import pathlib
+import shutil
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import lavafuncs  # pylint: disable=wrong-import-position
+from scripts.context import Context  # pylint: disable=wrong-import-position
+from scripts.ilapfuncs import sanitize_report_name  # pylint: disable=wrong-import-position
+
+# Reserved words an artifact could plausibly want as a column heading. 'From' and 'To' are
+# the ones that actually bit (mastodon notifications, Apple Mail); the rest are the same
+# hazard waiting for the next module.
+RESERVED_HEADERS = [
+    'From', 'To', 'Order', 'Group', 'Index', 'Select', 'Where', 'Table',
+    'Values', 'Default', 'Check', 'References', 'Limit', 'Join', 'Set', 'Action',
+]
+
+
+class TestLavaReservedWordIdentifiers(unittest.TestCase):
+    """The LAVA SQLite writer must quote identifiers so reserved words are usable."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        lavafuncs.initialize_lava(self.tmpdir, self.tmpdir, 'fs')
+
+    def tearDown(self):
+        if lavafuncs.lava_db is not None:
+            lavafuncs.lava_db.close()
+            lavafuncs.lava_db = None
+        lavafuncs.lava_data = None
+        Context.clear()
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _fetch_rows(self, table_name):
+        cursor = lavafuncs.lava_db.cursor()
+        return cursor.execute(f'SELECT * FROM "{table_name}"').fetchall()
+
+    def test_reserved_words_are_hostile_unquoted(self):
+        """Documents why RESERVED_HEADERS is the corpus: unquoted, these really do fail."""
+        db = sqlite3.connect(':memory:')
+        offenders = []
+        for header in RESERVED_HEADERS:
+            column = lavafuncs.sanitize_sql_name(header)
+            try:
+                db.execute(f'CREATE TABLE t_{column} ({column} TEXT)')
+            except sqlite3.OperationalError:
+                offenders.append(header)
+        db.close()
+        self.assertIn('From', offenders)
+        self.assertIn('Order', offenders)
+        self.assertGreaterEqual(
+            len(offenders), 5,
+            'Test corpus no longer exercises the bug; add headers SQLite rejects unquoted.')
+
+    def test_create_table_accepts_reserved_word_headers(self):
+        table_name, column_map, object_columns = lavafuncs.lava_create_sqlite_table(
+            'reserved_word_artifact', RESERVED_HEADERS)
+
+        self.assertEqual(table_name, 'reserved_word_artifact')
+        self.assertEqual(object_columns, {})
+        self.assertEqual(
+            [column_map[lavafuncs.sanitize_sql_name(h)] for h in RESERVED_HEADERS],
+            RESERVED_HEADERS)
+
+        cursor = lavafuncs.lava_db.cursor()
+        columns = [row[1] for row in cursor.execute(f'PRAGMA table_info("{table_name}")')]
+        self.assertEqual(columns, [lavafuncs.sanitize_sql_name(h) for h in RESERVED_HEADERS])
+
+    def test_insert_populates_reserved_word_columns(self):
+        table_name, column_map, object_columns = lavafuncs.lava_create_sqlite_table(
+            'reserved_word_artifact', RESERVED_HEADERS)
+        rows = [
+            tuple(f'{header}-row1' for header in RESERVED_HEADERS),
+            tuple(f'{header}-row2' for header in RESERVED_HEADERS),
+        ]
+
+        lavafuncs.lava_insert_sqlite_data(
+            table_name, rows, object_columns, RESERVED_HEADERS, column_map)
+
+        self.assertEqual(self._fetch_rows(table_name), rows)
+
+        # Values must land in the column they were written for, not just somewhere.
+        cursor = lavafuncs.lava_db.cursor()
+        self.assertEqual(
+            cursor.execute(f'SELECT "from", "order" FROM "{table_name}"').fetchall(),
+            [('From-row1', 'Order-row1'), ('From-row2', 'Order-row2')])
+
+    def test_reserved_word_table_name(self):
+        """A module function named e.g. order() makes the table name reserved too."""
+        table_name, column_map, object_columns = lavafuncs.lava_create_sqlite_table(
+            'Order', ['From', 'Timestamp'])
+
+        self.assertEqual(table_name, 'order')
+        lavafuncs.lava_insert_sqlite_data(
+            table_name, [('sender', 'ts')], object_columns, ['From', 'Timestamp'], column_map)
+        self.assertEqual(self._fetch_rows(table_name), [('sender', 'ts')])
+
+    def test_typed_headers_with_reserved_words(self):
+        """Tuple headers take the typed CREATE TABLE branch, which needs quoting too."""
+        headers = [('From', 'datetime'), ('Order', 'datetime'), 'Group']
+        table_name, column_map, object_columns = lavafuncs.lava_create_sqlite_table(
+            'typed_reserved_artifact', headers)
+
+        self.assertEqual(object_columns, {'from': 'datetime', 'order': 'datetime'})
+
+        timestamp = datetime.datetime(2026, 7, 25, 12, 0, tzinfo=datetime.timezone.utc)
+        lavafuncs.lava_insert_sqlite_data(
+            table_name, [(timestamp, timestamp, 'a group')], object_columns, headers, column_map)
+
+        self.assertEqual(
+            self._fetch_rows(table_name),
+            [(int(timestamp.timestamp()), int(timestamp.timestamp()), 'a group')])
+
+    def test_process_artifact_end_to_end(self):
+        """The path artifact_processor actually takes, headers and all."""
+        Context.set_artifact_info({'name': 'Reserved Words', 'description': 'test artifact'})
+        # Only the basename is read, so this path never has to exist. Keeping it synthetic
+        # lets the same test file be shared across the LEAPP tools unchanged.
+        Context.set_module_file_path(str(REPO_ROOT / 'scripts' / 'artifacts' / 'reserved_words.py'))
+
+        table_name, object_columns, column_map = lavafuncs.lava_process_artifact(
+            'Testing', 'reserved_words_module', 'Reserved Words', RESERVED_HEADERS,
+            record_count=1, func_name='reserved_words')
+        lavafuncs.lava_insert_sqlite_data(
+            table_name,
+            [tuple(f'{header}-value' for header in RESERVED_HEADERS)],
+            object_columns, RESERVED_HEADERS, column_map)
+
+        self.assertEqual(table_name, 'reserved_words')
+        self.assertEqual(len(self._fetch_rows(table_name)), 1)
+        artifact = lavafuncs.lava_data['artifacts']['Testing'][0]
+        self.assertEqual(artifact['tablename'], 'reserved_words')
+        self.assertEqual(artifact['record_count'], 1)
+
+
+class TestQuoteSqlName(unittest.TestCase):
+    """quote_sql_name() must not be escapable by whatever ends up in a header."""
+
+    def test_wraps_in_double_quotes(self):
+        self.assertEqual(lavafuncs.quote_sql_name('from'), '"from"')
+
+    def test_doubles_embedded_quotes(self):
+        self.assertEqual(lavafuncs.quote_sql_name('a"b'), '"a""b"')
+
+    def test_embedded_quote_is_a_usable_identifier(self):
+        # sanitize_sql_name() strips quotes today, so this only guards quote_sql_name()
+        # itself against a future caller that skips sanitizing.
+        db = sqlite3.connect(':memory:')
+        column = lavafuncs.quote_sql_name('odd"name')
+        db.execute(f'CREATE TABLE t ({column} TEXT)')
+        db.execute(f'INSERT INTO t ({column}) VALUES (?)', ('value',))
+        self.assertEqual(db.execute('SELECT * FROM t').fetchall(), [('value',)])
+        db.close()
+
+
+class TestSanitizeReportName(unittest.TestCase):
+    """Artifact names and categories become file and folder names."""
+
+    def test_leaves_ordinary_names_alone(self):
+        # Existing artifact names must keep producing byte-identical output paths.
+        for name in ['SMS & iMessage', "Apple Maps", 'Twitter X - Direct Messages']:
+            self.assertEqual(sanitize_report_name(name), name)
+
+    def test_replaces_path_separators(self):
+        self.assertEqual(sanitize_report_name('Twitter/X'), 'Twitter_X')
+        self.assertEqual(sanitize_report_name('Foo\\Bar'), 'Foo_Bar')
+
+    def test_result_is_a_single_path_component(self):
+        import os
+        safe_name = sanitize_report_name('Twitter/X - Cached Posts')
+        self.assertEqual(os.path.basename(safe_name), safe_name)
+        self.assertEqual(os.path.dirname(safe_name), '')
+
+    def test_no_shipped_artifact_needs_sanitizing(self):
+        """Nothing in scripts/artifacts should rely on the fallback."""
+        import re
+        offenders = []
+        pattern = re.compile(r"^\s*'(name|category)':\s*(['\"])(.*?)\2", re.MULTILINE)
+        for py_file in sorted((REPO_ROOT / 'scripts' / 'artifacts').glob('*.py')):
+            source = py_file.read_text(encoding='utf-8', errors='replace')
+            for _, _, value in pattern.findall(source):
+                if '/' in value or '\\' in value:
+                    offenders.append(f'{py_file.name}: {value}')
+        self.assertEqual(
+            offenders, [],
+            'Artifact name/category contains a path separator; the report file name will '
+            'not match the displayed name:\n' + '\n'.join(offenders))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/dleapp.py
+++ b/dleapp.py
@@ -486,7 +486,8 @@ def crunch_artifacts(
         if files_found:
             if not lava_only and 'lava_only' in output_types:
                 lava_only = True
-            category_folder = os.path.join(out_params.output_folder_base, '_HTML', plugin.category)
+            category_folder = os.path.join(out_params.output_folder_base, '_HTML',
+                                           sanitize_report_name(plugin.category, 'category'))
             if not os.path.exists(category_folder):
                 try:
                     os.makedirs(category_folder)

--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -432,6 +432,34 @@ def get_data_list_with_media(media_header_info, data_list):
 
     return html_data_list, txt_data_list
 
+_reported_unsafe_report_names = set()
+
+def sanitize_report_name(name, kind='name'):
+    """
+    Replaces path separators in an artifact name or category so it is usable as a file
+    or folder name.
+
+    Artifact names become HTML/TSV/KML filenames and categories become _HTML subfolder
+    names. A name such as 'Twitter/X' makes os.path.join() read the '/' as a path
+    separator, so the artifact either fails to write its report or lands in an
+    unintended folder, even though the parser ran fine. The original name is kept for
+    display and for LAVA; only the on-disk name is rewritten.
+
+    Args:
+        name (str): The artifact name or category to make path safe.
+        kind (str): What is being sanitized, used in the warning ('name' or 'category').
+    Returns:
+        str: The name with '/' and '\\' replaced by '_'.
+    """
+
+    safe_name = name.replace('/', '_').replace('\\', '_')
+    if safe_name != name and name not in _reported_unsafe_report_names:
+        _reported_unsafe_report_names.add(name)
+        logfunc(f"Warning: artifact {kind} '{name}' contains a path separator. "
+                f"Report files use '{safe_name}' instead; rename it to avoid the mismatch.")
+    return safe_name
+
+
 def artifact_processor(func):
     @wraps(func)
     def wrapper(files_found, report_folder, seeker, wrap_text):
@@ -479,7 +507,12 @@ def artifact_processor(func):
             else:
                 html_data_list = data_list
             logfunc(f"Found {len(data_list):,} {'records' if len(data_list)>1 else 'record'} for {artifact_name}")
-            icons.setdefault(category, {artifact_name: icon}).update({artifact_name: icon})
+            # Path separators would break (or misplace) the report files, so the HTML, TSV
+            # and KML outputs are written under a path safe name. The sidebar keys off the
+            # on-disk names, so the icon lookup has to use the same safe names.
+            safe_artifact_name = sanitize_report_name(artifact_name)
+            safe_category = sanitize_report_name(category, 'category')
+            icons.setdefault(safe_category, {safe_artifact_name: icon}).update({safe_artifact_name: icon})
 
             # Strip tuples from headers for HTML, TSV, and timeline
             stripped_headers = strip_tuple_from_headers(data_headers)
@@ -492,13 +525,13 @@ def artifact_processor(func):
 
             if check_output_types('html', output_types):
                 report = artifact_report.ArtifactHtmlReport(artifact_name)
-                report.start_artifact_report(report_folder, artifact_name, description)
+                report.start_artifact_report(report_folder, safe_artifact_name, description)
                 report.add_script()
                 report.write_artifact_data_table(stripped_headers, html_data_list, source_path, html_no_escape=html_columns)
                 report.end_artifact_report()
 
             if check_output_types('tsv', output_types):
-                tsv(report_folder, stripped_headers, txt_data_list if media_header_info else data_list, artifact_name)
+                tsv(report_folder, stripped_headers, txt_data_list if media_header_info else data_list, safe_artifact_name)
 
             if check_output_types('timeline', output_types):
                 timeline(report_folder, artifact_name, txt_data_list if media_header_info else data_list, stripped_headers)
@@ -518,7 +551,7 @@ def artifact_processor(func):
                 lava_insert_sqlite_data(table_name, data_list, object_columns, data_headers, column_map)
 
             if check_output_types('kml', output_types):
-                kmlgen(report_folder, artifact_name, txt_data_list if media_header_info else data_list, stripped_headers)
+                kmlgen(report_folder, safe_artifact_name, txt_data_list if media_header_info else data_list, stripped_headers)
 
         else:
             if output_types != 'none':


### PR DESCRIPTION
Brings DLEAPP up to parity with iLEAPP/ALEAPP/RLEAPP/VLEAPP on the CI and test side of the LAVA writer fix, and ports the one piece of that fix that PR #18 did not carry.

## What's here

**fix: path-safe report names.** The `quote_sql_name` half of the LAVA writer fix landed with the Signal Desktop parser (#18), but `sanitize_report_name()` never made it over. An artifact name or category containing `/` or `\` becomes an HTML/TSV/KML filename or `_HTML` folder name, so `os.path.join()` reads it as a path separator and the report is misplaced or fails to write even though the parser ran fine. Ported from RLEAPP `38a0907` (originally iLEAPP): HTML/TSV/KML outputs use a path-safe name; display names, timeline entries and the LAVA JSON keep the original.

**Admin test suite** (`admin/test/scripts/`, shared with the other LEAPP repos):
- `test_lava_sql_identifiers.py` — 13 regression tests for the LAVA writer against a real SQLite file; the module harness mocks the LAVA connection, so it can never catch this class of bug.
- `test_artifact_imports.py` — imports every artifact module; run across the version matrix this is the only check that a change parses on the oldest supported Python. Floors set to DLEAPP's current size (17 modules, 39 plugins).
- `test_entry_points.py` — `dleapp.py` must import and expose `main()`; `dleappGUI.py` must compile (it builds its window at module level, so importing needs a display CI does not have).

**Workflows:**
- `python_runtime_contract.yml` — runs the suite on Python 3.10/3.11/3.12, path-filtered to include `scripts/**` and both entry points (the filter gap that once let a 3.12-only f-string ship broken in ALEAPP).
- `python_lint.yml` + `admin/scripts/lint_changed.py` — diff-aware pylint: lints the changed files at the merge base and at the change, fails only on warnings the PR introduces, so pre-existing structural debt in the wildcard-import entry points doesn't turn unrelated PRs red.

## Verification

- All 17 tests pass locally.
- `lint_changed.py` against the merge base: 25 pre-existing warnings, 25 now, no new warnings.
- Both new workflows trigger on this PR itself, so this PR is also their first live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)