### PR TITLE
Clear the pylint warnings the new lint CI reports

### DIFF
--- a/scripts/artifacts/discordAccount.py
+++ b/scripts/artifacts/discordAccount.py
@@ -147,7 +147,8 @@ def discordAccount(context):
     for folder in leveldb_folders(files_found):
         try:
             records = sorted(read_records(folder), key=lambda r: -r.sequence)
-        except Exception as ex:
+        # Deliberately broad: a damaged LevelDB must not stop the artifact.
+        except Exception as ex:  # pylint: disable=broad-exception-caught
             logfunc(f"Discord Account: could not read Local Storage '{folder}': {ex}")
             continue
         source_path = source_path or folder

--- a/scripts/artifacts/discordContacts.py
+++ b/scripts/artifacts/discordContacts.py
@@ -177,7 +177,8 @@ def _channel_to_server(scan, files_found):
     for folder in leveldb_folders(files_found):
         try:
             records = list(read_records(folder))
-        except Exception:
+        # Deliberately broad: a damaged LevelDB must not stop the mapping.
+        except Exception:  # pylint: disable=broad-exception-caught
             continue
         for record in records:
             if record.key != "SelectedChannelStore":

--- a/scripts/artifacts/discordLocalStorage.py
+++ b/scripts/artifacts/discordLocalStorage.py
@@ -96,7 +96,8 @@ def _records(context):
     for folder in leveldb_folders([str(f) for f in context.get_files_found()]):
         try:
             records.extend(read_records(folder))
-        except Exception as ex:
+        # Deliberately broad: a damaged LevelDB must not stop the artifact.
+        except Exception as ex:  # pylint: disable=broad-exception-caught
             logfunc(f"Discord Local Storage: could not read '{folder}': {ex}")
     records.sort(key=lambda record: -record.sequence)
     return records

--- a/scripts/artifacts/signalAccount.py
+++ b/scripts/artifacts/signalAccount.py
@@ -176,7 +176,8 @@ def signalAccount(context):
             ("Protocol Sessions", "SELECT COUNT(*) FROM sessions")):
         try:
             add(f"Records: {label}", connection.execute(query).fetchone()[0], database_path)
-        except Exception:
+        # Deliberately broad: a missing table must not stop the summary.
+        except Exception:  # pylint: disable=broad-exception-caught
             continue
 
     connection.close()

--- a/scripts/artifacts/signalContacts.py
+++ b/scripts/artifacts/signalContacts.py
@@ -180,7 +180,8 @@ def signalCalls(context):
     try:
         rows = connection.execute("""SELECT callId, peerId, ringerId, mode, type, direction,
                                             status, timestamp, endedTimestamp FROM callsHistory""")
-    except Exception as ex:
+    # Deliberately broad: an older schema may lack this table.
+    except Exception as ex:  # pylint: disable=broad-exception-caught
         logfunc(f"Signal Calls: call history unavailable ({ex}).")
         connection.close()
         return data_headers, [], ""
@@ -245,7 +246,8 @@ def signalSessions(context):
                 "", "", "",
                 context.get_relative_path(_source(files_found)),
             ))
-    except Exception as ex:
+    # Deliberately broad: an older schema may lack this table.
+    except Exception as ex:  # pylint: disable=broad-exception-caught
         logfunc(f"Signal Sessions: sessions table unavailable ({ex}).")
 
     try:
@@ -265,7 +267,8 @@ def signalSessions(context):
                 "Yes" if record.get("nonblockingApproval") else "",
                 context.get_relative_path(_source(files_found)),
             ))
-    except Exception as ex:
+    # Deliberately broad: an older schema may lack this table.
+    except Exception as ex:  # pylint: disable=broad-exception-caught
         logfunc(f"Signal Sessions: identityKeys table unavailable ({ex}).")
 
     connection.close()

--- a/scripts/artifacts/signalMessages.py
+++ b/scripts/artifacts/signalMessages.py
@@ -128,7 +128,8 @@ def _service_id_labels(connection, labels):
     try:
         rows = connection.execute(
             "SELECT serviceId, id FROM conversations WHERE serviceId IS NOT NULL")
-    except Exception:
+    # Deliberately broad: an older schema may lack the attachment table.
+    except Exception:  # pylint: disable=broad-exception-caught
         return mapping
     for service_id, cid in rows:
         if service_id:
@@ -167,7 +168,8 @@ def signalMessages(context):
         for message_id, path, local_key, size, content_type, file_name, plain_hash in rows:
             attachments.setdefault(message_id, []).append(
                 (path, local_key, size, content_type, file_name, plain_hash))
-    except Exception as ex:
+    # Deliberately broad: an older schema may lack the attachment table.
+    except Exception as ex:  # pylint: disable=broad-exception-caught
         logfunc(f"Signal Messages: attachment table unavailable ({ex}).")
 
     data_list = []

--- a/scripts/chromium/discord_api.py
+++ b/scripts/chromium/discord_api.py
@@ -198,7 +198,7 @@ class DiscordCacheScan:
 
     # -- population helpers ------------------------------------------------ #
 
-    def _note_user(self, user, seen_in, when):
+    def note_user(self, user, seen_in, when):
         if not isinstance(user, dict) or not user.get("id"):
             return
         uid = user["id"]
@@ -219,7 +219,7 @@ class DiscordCacheScan:
             if record["last_seen"] is None or when > record["last_seen"]:
                 record["last_seen"] = when
 
-    def _note_channel(self, channel, source=""):
+    def note_channel(self, channel, source=""):
         if not isinstance(channel, dict) or not channel.get("id"):
             return
         cid = channel["id"]
@@ -239,11 +239,11 @@ class DiscordCacheScan:
             record["recipients"] = ", ".join(
                 user_display(r) for r in recipients if isinstance(r, dict))
         for recipient in recipients:
-            self._note_user(recipient, "DM channel", None)
+            self.note_user(recipient, "DM channel", None)
         if channel.get("guild_id"):
-            self._note_guild({"id": channel["guild_id"]}, source)
+            self.note_guild({"id": channel["guild_id"]}, source)
 
-    def _note_guild(self, guild, source=""):
+    def note_guild(self, guild, source=""):
         if not isinstance(guild, dict) or not guild.get("id"):
             return
         gid = str(guild["id"])
@@ -262,7 +262,7 @@ class DiscordCacheScan:
             record["features"] = ", ".join(
                 str(f) for f in guild["features"] if isinstance(f, str))
 
-    def _add_message(self, message, source, cached_at):
+    def add_message(self, message, source, cached_at):
         if not isinstance(message, dict) or not message.get("id"):
             return
         mid = message["id"]
@@ -273,11 +273,11 @@ class DiscordCacheScan:
             return
         self.messages[mid] = {"message": message, "source": source, "cached": cached_at}
         sent = iso_to_datetime(message.get("timestamp")) or snowflake_to_datetime(mid)
-        self._note_user(message.get("author"), "Message author", sent)
+        self.note_user(message.get("author"), "Message author", sent)
         for mention in message.get("mentions") or []:
-            self._note_user(mention, "Mentioned", sent)
+            self.note_user(mention, "Mentioned", sent)
         if message.get("channel_id"):
-            self._note_channel({"id": message["channel_id"]}, source)
+            self.note_channel({"id": message["channel_id"]}, source)
 
 
 def _decode_json(entry):
@@ -322,7 +322,8 @@ def find_local_account(files_found):
     for folder in leveldb_folders(files_found):
         try:
             records = list(read_records(folder))
-        except Exception:
+        # Deliberately broad: one malformed cached response must not stop the scan.
+        except Exception:  # pylint: disable=broad-exception-caught
             continue
         for record in sorted(records, key=lambda r: -r.sequence):
             if record.key == "MultiAccountStore":
@@ -406,7 +407,8 @@ def scan_cache(files_found, log=None):
 
         try:
             _parse_api_entry(scan, entry, endpoint, cached_at, requested_at)
-        except Exception as ex:  # a single malformed response must not stop the scan
+        # Deliberately broad: a damaged LevelDB must not stop key discovery.
+        except Exception as ex:  # a single malformed response must not stop the scan  # pylint: disable=broad-exception-caught
             if log:
                 log(f"Discord: could not parse cached '{endpoint}': {ex}")
 
@@ -421,7 +423,7 @@ def _parse_api_entry(scan, entry, endpoint, cached_at, requested_at):
         payload = _decode_json(entry)
         if isinstance(payload, list):
             for message in payload:
-                scan._add_message(message, entry.path, cached_at)
+                scan.add_message(message, entry.path, cached_at)
         return
 
     match = _MESSAGE_SEARCH_RE.match(endpoint)
@@ -439,11 +441,11 @@ def _parse_api_entry(scan, entry, endpoint, cached_at, requested_at):
         if isinstance(payload, dict):
             for group in payload.get("messages") or []:
                 for message in (group if isinstance(group, list) else [group]):
-                    scan._add_message(message, entry.path, cached_at)
+                    scan.add_message(message, entry.path, cached_at)
                     if isinstance(message, dict) and message.get("hit"):
                         hits.append(message)
             for channel in payload.get("channels") or []:
-                scan._note_channel(channel, entry.path)
+                scan.note_channel(channel, entry.path)
         scan.searches.append({
             "type": "Message search",
             "scope": f"{match.group(1).rstrip('s')} {match.group(2)}",
@@ -462,7 +464,7 @@ def _parse_api_entry(scan, entry, endpoint, cached_at, requested_at):
         emoji = unquote(match.group(3))
         if isinstance(payload, list):
             for user in payload:
-                scan._note_user(user, "Reacted to message", cached_at)
+                scan.note_user(user, "Reacted to message", cached_at)
                 scan.reactions.append({
                     "channel_id": match.group(1), "message_id": match.group(2),
                     "emoji": emoji, "user": user,
@@ -476,21 +478,21 @@ def _parse_api_entry(scan, entry, endpoint, cached_at, requested_at):
         if isinstance(payload, dict) and payload.get("user"):
             scan.profiles[match.group(1)] = {"profile": payload, "source": entry.path,
                                              "cached": cached_at}
-            scan._note_user(payload["user"], "Profile viewed", cached_at)
+            scan.note_user(payload["user"], "Profile viewed", cached_at)
         return
 
     match = _CHANNEL_RE.match(endpoint)
     if match:
         payload = _decode_json(entry)
         if isinstance(payload, dict):
-            scan._note_channel(payload, entry.path)
+            scan.note_channel(payload, entry.path)
         return
 
     match = _GUILD_PROFILE_RE.match(endpoint)
     if match:
         payload = _decode_json(entry)
         if isinstance(payload, dict) and payload.get("name"):
-            scan._note_guild(payload, entry.path)
+            scan.note_guild(payload, entry.path)
         return
 
     match = _INVITE_RE.match(endpoint)
@@ -499,18 +501,18 @@ def _parse_api_entry(scan, entry, endpoint, cached_at, requested_at):
         if isinstance(payload, dict) and payload.get("code"):
             scan.invites.append({"invite": payload, "cached": cached_at,
                                  "source": entry.path})
-            scan._note_user(payload.get("inviter"), "Invite creator", cached_at)
+            scan.note_user(payload.get("inviter"), "Invite creator", cached_at)
             guild = payload.get("guild")
             if guild:
                 guild = dict(guild)
                 guild.setdefault("approximate_member_count",
                                  payload.get("approximate_member_count"))
-                scan._note_guild(guild, entry.path)
+                scan.note_guild(guild, entry.path)
             if payload.get("channel"):
                 channel = dict(payload["channel"])
                 if guild and guild.get("id"):
                     channel.setdefault("guild_id", guild["id"])
-                scan._note_channel(channel, entry.path)
+                scan.note_channel(channel, entry.path)
         return
 
     match = _GIF_SEARCH_RE.match(endpoint)

--- a/scripts/chromium/simple_cache.py
+++ b/scripts/chromium/simple_cache.py
@@ -75,9 +75,23 @@ class CacheEntry:
                  "response_time", "status_code", "status_line", "headers",
                  "body_offset", "body_size")
 
-    def __init__(self, **kwargs):
-        for slot in self.__slots__:
-            setattr(self, slot, kwargs.get(slot))
+    # Assigned one by one rather than by looping over __slots__: a loop hides
+    # the attributes from static analysis, and a cache of tens of thousands of
+    # entries is a poor place for a typo to go unnoticed.
+    def __init__(self, path=None, key=None, url=None, key_prefix=None,
+                 request_time=None, response_time=None, status_code=None,
+                 status_line=None, headers=None, body_offset=None, body_size=None):
+        self.path = path
+        self.key = key
+        self.url = url
+        self.key_prefix = key_prefix
+        self.request_time = request_time
+        self.response_time = response_time
+        self.status_code = status_code
+        self.status_line = status_line
+        self.headers = headers
+        self.body_offset = body_offset
+        self.body_size = body_size
 
     @property
     def content_type(self):
@@ -131,7 +145,8 @@ def decode_body(data, encoding):
 
                 return zstandard.ZstdDecompressor().decompress(data)
             return zstd.decompress(data)
-    except Exception:
+    # Deliberately broad: any decompressor may fail on a truncated body.
+    except Exception:  # pylint: disable=broad-exception-caught
         # A partially evicted or unsupported body is still worth returning raw.
         return data
     return data

--- a/scripts/signal_desktop.py
+++ b/scripts/signal_desktop.py
@@ -29,6 +29,7 @@ The result is the 64 character hex string Signal passes to
 import base64
 import hashlib
 import hmac
+import importlib.util
 import json
 import os
 import re
@@ -66,11 +67,8 @@ KDF_ALGORITHM = "sha512"
 
 
 def crypto_available():
-    try:
-        import Crypto.Cipher.AES  # noqa: F401
-        return True
-    except ImportError:
-        return False
+    """True when PyCryptodome is installed, which the unwrap and decrypt need."""
+    return importlib.util.find_spec("Crypto.Cipher.AES") is not None
 
 
 def unwrap_encrypted_key(encrypted_key_hex, credential):
@@ -184,7 +182,8 @@ def resolve_database_key(files_found, log=None):
     try:
         from scripts.context import Context
         supplied = Context.get_app_secret("signal")
-    except Exception:
+    except (ImportError, AttributeError):
+        # Older cores have no app-secret store; the other inputs still work.
         supplied = None
     if supplied:
         secrets.insert(0, ("--signal-key", supplied))
@@ -431,7 +430,8 @@ def decrypt_database(database_path, key_hex, output_path, log=None):
             database_path, key_hex, output_path,
             page_size=PAGE_SIZE, hmac_algorithm=HMAC_ALGORITHM,
             kdf_algorithm=KDF_ALGORITHM, raw_key=True, apply_wal=True)
-    except Exception as ex:  # a malformed image should not stop the module
+    # Deliberately broad: a malformed database image must not stop the module.
+    except Exception as ex:  # a malformed image should not stop the module  # pylint: disable=broad-exception-caught
         if log:
             log(f"Signal Desktop: could not decrypt '{database_path}': {ex}")
         return None


### PR DESCRIPTION
The diff-aware linter landed in #20 alongside the Discord and Signal work, so those modules were never checked by it. They introduce 32 warnings against a baseline of 71, which would turn the next pull request touching any of them red for reasons unrelated to that change.

## Fixes

**`CacheEntry` hid its own attributes.** It assigned them by looping over `__slots__` with `setattr`, so static analysis could not see a single one — seven `no-member` errors, and no protection against a typo in a class that represents tens of thousands of cache entries. Assigned explicitly now.

**`crypto_available()` imported a module just to test for it.** `importlib.util.find_spec` answers the same question with no unused import.

**Four scan methods were private in name only.** `note_user`, `note_channel`, `note_guild` and `add_message` are called by module-level helpers, which is what the ten `protected-access` warnings were pointing at. Renamed to match how they are actually used.

**One over-broad catch narrowed.** The `Context` lookup for a supplied secret caught everything; it only needs `ImportError` and `AttributeError`, for a core without the app-secret store.

## The remaining broad catches are deliberate

Thirteen guard a parser or store that can fail in many ways on real data: one malformed cached response, a damaged LevelDB, or an older schema missing a table must not stop an artifact. Each now carries a `# pylint: disable=broad-exception-caught` with the reason in place, rather than a blanket disable — so a careless broad catch added later still shows up.

## Verification

- 10.00/10 on the changed files with the CI's own command
- 17 admin tests pass, including the new SQL identifier regression test
- 39 plugins load: 16 Discord, 7 Signal
- Discord row counts re-verified through the registry: 16 artifacts, no mismatches
- Signal parses unchanged