### PR TITLE
Use a blue GUI accent so DLEAPP stops reading as iLEAPP

### DIFF
--- a/dleappGUI.py
+++ b/dleappGUI.py
@@ -768,11 +768,13 @@ modules_filter_var.trace_add("write", filter_modules)  # Trigger filtering on in
 pickModules()
 
 ## Theme properties  (DLEAPP brand palette, taken from the logo artwork)
+## The accent is the logo's blue (#3290EB) lightened to clear 3:1 against the
+## plum base; the logo gold is left to iLEAPP, which already owns that accent.
 theme_bgcolor = '#5F3A5C'      # plum / aubergine base
 theme_inputcolor = '#D5D9DE'   # grey input fields (black text)
-theme_inputfgcolor = '#F2B035' # gold accent
+theme_inputfgcolor = '#70ADEB' # blue accent
 theme_fgcolor = '#F7F0E0'      # cream text on plum
-theme_button = '#F2B035'       # gold accent buttons (black text)
+theme_button = '#70ADEB'       # blue accent buttons (black text)
 
 if is_platform_macos():
     mlist_window_height = 24


### PR DESCRIPTION
## Why

DLEAPP's GUI accent was gold `#F2B035`, which sits 12 ΔE from iLEAPP's signature `#fdcb52` at effectively the same hue (39° vs 42°). That is "different batch of the same paint," not a different color, so every gold-tinted piece of DLEAPP chrome (buttons, scrollbar thumbs, progress bar) read as iLEAPP chrome. RLEAPP also uses `#fdcb52` for its input accent, so gold was already doing double duty in the family.

The plum base was never the problem — it is 30 ΔE or more from every sibling background and was picked as unclaimed on purpose.

## What changed

Only the two accent values in the theme block of `dleappGUI.py`.

The logo's secondary blue could not be used as-is. `#2A7FD4` from the generator's palette comment gives only 2.26:1 against the plum background, and the blue actually rendered in the artwork (`#3290EB`) gives 2.82:1 — both under the 3:1 floor for a UI control, so buttons would have sunk into the window. Keeping hue 210 and the artwork's saturation, lightened to `#70ADEB`:

| | gold (before) | `#70ADEB` (after) |
|---|---|---|
| Black button label | 11.04:1 | 8.87:1 |
| Button vs plum background | 4.91:1 | 3.95:1 |
| Nearest sibling GUI accent | 12 ΔE (iLEAPP) | 54 ΔE (ALEAPP) |

Nearest LEAPP color of any kind is now RLEAPP's window background at 27 ΔE — different role, different hue.

## Deliberately left alone

- **`admin/scripts/generate_logo.py`** — the wordmark stays gold, so the logo and icon are unchanged. Gold is therefore still visible in a DLEAPP screenshot via the banner image. The iLEAPP resemblance is reduced, not erased; repainting the wordmark is a bigger call.
- **`scripts/_elements/dashboard.css`** — the HTML report accent stays gold. iLEAPP's report accent is red `#d02e26`, so there was never a collision there. Propagating blue would land 17 ΔE from RLEAPP's report accent `#62a1c3` and trade a solved collision for a new one, in the artifact people actually share.

## Testing

Launched the GUI on macOS and confirmed the blue chrome renders and the window comes up clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)