### PR TITLE
Confirm the keychain KDF from securityd and fix what a failed unlock reports

### DIFF
--- a/admin/test/scripts/test_macos_keychain.py
+++ b/admin/test/scripts/test_macos_keychain.py
@@ -1,16 +1,16 @@
-"""Cover the macOS keychain reader's key derivation and its known limits.
+"""Cover the macOS keychain reader's key derivation and its failure semantics.
 
 A keychain's DbBlob stores the PBKDF2 salt but not the digest or the iteration
-count that were used with it, so the reader has to carry them. Only SHA-1 with
-1000 rounds is confirmed, and it opens everything `security create-keychain`
-writes. That is also why the reader looked healthy for so long: every keychain
-built for testing uses that set.
+count, so the reader carries them. They are fixed in securityd: HMAC-SHA1, 1000
+rounds, 24 bytes, unconditional. `test_other_parameters_are_not_opened` exists
+because an earlier investigation talked itself into believing real login
+keychains used SHA-256/10000, on the strength of a padding check a wrong key
+passes about 1 time in 256.
 
-It does not open a real login.keychain-db, and the cause is unresolved. These
-tests therefore do two jobs: check the derivation works for every parameter set
-the reader declares, and pin the fact that SHA-256/10000 is deliberately absent,
-so a future change has to bring evidence rather than repeat an earlier guess.
-See `_KDF_PARAMETERS` for what that evidence has to be.
+The distinction these tests protect is the one that investigation got wrong: a
+None from the reader means "this password did not open this keychain", not "the
+examiner mistyped". A login keychain can hold a password that differs from the
+account password, and a live macOS host will not reveal it.
 
 The synthetic-DbBlob tests need no keychain and run on the Linux CI runners. The
 live-keychain test exercises the whole path — table walk, key unwrap, SSGP
@@ -73,38 +73,28 @@ class TestDatabaseKeyDerivation(unittest.TestCase):
         data = b'\xaa' * 64 + blob
         return macos_keychain._database_key(data, 64, password or self.PASSWORD)  # pylint: disable=protected-access
 
-    def test_confirmed_parameters(self):
-        """SHA-1 / 1000: the set `security create-keychain` writes."""
+    def test_securityd_parameters(self):
+        """The values securityd uses, which are fixed and never negotiated."""
+        self.assertEqual(macos_keychain._KDF_DIGEST, 'sha1')  # pylint: disable=protected-access
+        self.assertEqual(macos_keychain._KDF_ROUNDS, 1000)  # pylint: disable=protected-access
         self.assertEqual(self._round_trip('sha1', 1000), self.DB_KEY)
 
-    def test_sha256_is_deliberately_not_declared(self):
-        """Pins the open question so nobody re-adds SHA-256 without evidence.
-
-        A sweep once appeared to show a real login.keychain-db using SHA-256 at
-        10000 rounds, but it judged candidates by 3DES padding alone, which a
-        wrong key satisfies about 1 time in 256. Adding it here on that basis
-        would be guessing. When someone confirms a parameter set properly --
-        by checking that the resulting database key unwraps the keychain's
-        symmetric keys, not just that padding validated -- this test is the
-        thing to change.
-        """
-        self.assertNotIn(('sha256', 10000), macos_keychain._KDF_PARAMETERS)  # pylint: disable=protected-access
-        self.assertIsNone(self._round_trip('sha256', 10000))
-
-    def test_every_declared_parameter_set_is_reachable(self):
-        """Nothing may be listed in _KDF_PARAMETERS that the reader cannot open."""
-        for digest, rounds in macos_keychain._KDF_PARAMETERS:  # pylint: disable=protected-access
-            with self.subTest(digest=digest, rounds=rounds):
-                self.assertEqual(self._round_trip(digest, rounds), self.DB_KEY)
-
     def test_wrong_password_yields_nothing(self):
-        for digest, rounds in macos_keychain._KDF_PARAMETERS:  # pylint: disable=protected-access
-            with self.subTest(digest=digest, rounds=rounds):
-                self.assertIsNone(self._round_trip(digest, rounds, password='not-the-password'))
+        self.assertIsNone(self._round_trip('sha1', 1000, password='not-the-password'))
 
-    def test_undeclared_parameters_are_not_opened(self):
-        """Confirms the tests above pass because of the table, not by chance."""
-        self.assertIsNone(self._round_trip('sha512', 7))
+    def test_other_parameters_are_not_opened(self):
+        """Confirms the test above passes because of the parameters, not by chance.
+
+        SHA-256/10000 is called out because a sweep once appeared to identify it
+        as what real login keychains use. It does not: that sweep scored
+        candidates by 3DES padding alone, which a wrong key satisfies about 1
+        time in 256, and the resulting key unwrapped 0 of 80 symmetric keys on a
+        real keychain. Apple's securityd derives the master key with HMAC-SHA1
+        at 1000 rounds unconditionally.
+        """
+        for digest, rounds in (('sha256', 10000), ('sha512', 7), ('sha1', 1001)):
+            with self.subTest(digest=digest, rounds=rounds):
+                self.assertIsNone(self._round_trip(digest, rounds))
 
 
 @unittest.skipUnless(HAS_SECURITY and HAS_CRYPTO, 'needs macOS `security` and PyCryptodome')

--- a/admin/test/scripts/test_macos_keychain.py
+++ b/admin/test/scripts/test_macos_keychain.py
@@ -1,17 +1,20 @@
-"""Guard the macOS keychain reader against the KDF parameters drifting again.
+"""Cover the macOS keychain reader's key derivation and its known limits.
 
 A keychain's DbBlob stores the PBKDF2 salt but not the digest or the iteration
-count that were used with it, so the reader has to know them. The reader
-originally hardcoded PBKDF2-HMAC-SHA1 with 1000 rounds, which is what
-`security create-keychain` still writes and therefore what every throwaway test
-keychain uses. A real login.keychain-db from a current macOS release uses
-SHA-256 with 10000 rounds, so the reader failed on the only file examiners
-actually feed it while passing every test built on a synthetic one.
+count that were used with it, so the reader has to carry them. Only SHA-1 with
+1000 rounds is confirmed, and it opens everything `security create-keychain`
+writes. That is also why the reader looked healthy for so long: every keychain
+built for testing uses that set.
 
-The synthetic-DbBlob tests below cover both parameter sets without needing a
-keychain at all, so they run on the Linux CI runners. The live-keychain test
-exercises the whole path — table walk, key unwrap, SSGP decrypt — and skips
-where `security` is unavailable.
+It does not open a real login.keychain-db, and the cause is unresolved. These
+tests therefore do two jobs: check the derivation works for every parameter set
+the reader declares, and pin the fact that SHA-256/10000 is deliberately absent,
+so a future change has to bring evidence rather than repeat an earlier guess.
+See `_KDF_PARAMETERS` for what that evidence has to be.
+
+The synthetic-DbBlob tests need no keychain and run on the Linux CI runners. The
+live-keychain test exercises the whole path — table walk, key unwrap, SSGP
+decrypt — and skips where `security` is unavailable.
 """
 import hashlib
 import os
@@ -70,13 +73,23 @@ class TestDatabaseKeyDerivation(unittest.TestCase):
         data = b'\xaa' * 64 + blob
         return macos_keychain._database_key(data, 64, password or self.PASSWORD)  # pylint: disable=protected-access
 
-    def test_current_parameters(self):
-        """SHA-256 / 10000: what a current macOS login.keychain-db uses."""
-        self.assertEqual(self._round_trip('sha256', 10000), self.DB_KEY)
-
-    def test_legacy_parameters(self):
-        """SHA-1 / 1000: older keychains, and anything `security create-keychain` makes."""
+    def test_confirmed_parameters(self):
+        """SHA-1 / 1000: the set `security create-keychain` writes."""
         self.assertEqual(self._round_trip('sha1', 1000), self.DB_KEY)
+
+    def test_sha256_is_deliberately_not_declared(self):
+        """Pins the open question so nobody re-adds SHA-256 without evidence.
+
+        A sweep once appeared to show a real login.keychain-db using SHA-256 at
+        10000 rounds, but it judged candidates by 3DES padding alone, which a
+        wrong key satisfies about 1 time in 256. Adding it here on that basis
+        would be guessing. When someone confirms a parameter set properly --
+        by checking that the resulting database key unwraps the keychain's
+        symmetric keys, not just that padding validated -- this test is the
+        thing to change.
+        """
+        self.assertNotIn(('sha256', 10000), macos_keychain._KDF_PARAMETERS)  # pylint: disable=protected-access
+        self.assertIsNone(self._round_trip('sha256', 10000))
 
     def test_every_declared_parameter_set_is_reachable(self):
         """Nothing may be listed in _KDF_PARAMETERS that the reader cannot open."""

--- a/admin/test/scripts/test_macos_keychain.py
+++ b/admin/test/scripts/test_macos_keychain.py
@@ -1,0 +1,160 @@
+"""Guard the macOS keychain reader against the KDF parameters drifting again.
+
+A keychain's DbBlob stores the PBKDF2 salt but not the digest or the iteration
+count that were used with it, so the reader has to know them. The reader
+originally hardcoded PBKDF2-HMAC-SHA1 with 1000 rounds, which is what
+`security create-keychain` still writes and therefore what every throwaway test
+keychain uses. A real login.keychain-db from a current macOS release uses
+SHA-256 with 10000 rounds, so the reader failed on the only file examiners
+actually feed it while passing every test built on a synthetic one.
+
+The synthetic-DbBlob tests below cover both parameter sets without needing a
+keychain at all, so they run on the Linux CI runners. The live-keychain test
+exercises the whole path — table walk, key unwrap, SSGP decrypt — and skips
+where `security` is unavailable.
+"""
+import hashlib
+import os
+import pathlib
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import macos_keychain  # pylint: disable=wrong-import-position
+
+# The DbBlob fields _database_key() unpacks, in order.
+_DB_BLOB = struct.Struct("> 8s I I 16s I 8s 20s 8s 20s")
+
+HAS_CRYPTO = macos_keychain.crypto_available()
+HAS_SECURITY = sys.platform == 'darwin' and shutil.which('security') is not None
+
+
+def _synthesize_db_blob(password, digest, rounds, db_key):
+    """Build the bytes of a DbBlob that `password` unlocks under these parameters.
+
+    Mirrors what securityd writes: PBKDF2 over the blob's salt gives the master
+    key, and 3DES-CBC under it and the blob IV encrypts the database key.
+    """
+    from Crypto.Cipher import DES3  # pylint: disable=import-outside-toplevel
+
+    salt = bytes(range(20))
+    iv = bytes(range(100, 108))
+    master = hashlib.pbkdf2_hmac(digest, password.encode('utf-8'), salt, rounds, 24)
+    pad = 8 - (len(db_key) % 8)
+    ciphertext = DES3.new(master, DES3.MODE_CBC, iv).encrypt(db_key + bytes([pad]) * pad)
+
+    start_crypto = _DB_BLOB.size
+    total_len = start_crypto + len(ciphertext)
+    header = _DB_BLOB.pack(
+        struct.pack('> I I', macos_keychain._COMMON_BLOB_MAGIC, 0),  # pylint: disable=protected-access
+        start_crypto, total_len, b'\x00' * 16, 0, b'\x00' * 8, salt, iv, b'\x00' * 20)
+    return header + ciphertext
+
+
+@unittest.skipUnless(HAS_CRYPTO, 'PyCryptodome is not installed')
+class TestDatabaseKeyDerivation(unittest.TestCase):
+    """_database_key() has to open a DbBlob under either published parameter set."""
+
+    PASSWORD = 'throwaway-test-password'
+    DB_KEY = bytes(range(1, 25))
+
+    def _round_trip(self, digest, rounds, password=None):
+        blob = _synthesize_db_blob(self.PASSWORD, digest, rounds, self.DB_KEY)
+        # Offset the blob so a hardcoded base address can't accidentally pass.
+        data = b'\xaa' * 64 + blob
+        return macos_keychain._database_key(data, 64, password or self.PASSWORD)  # pylint: disable=protected-access
+
+    def test_current_parameters(self):
+        """SHA-256 / 10000: what a current macOS login.keychain-db uses."""
+        self.assertEqual(self._round_trip('sha256', 10000), self.DB_KEY)
+
+    def test_legacy_parameters(self):
+        """SHA-1 / 1000: older keychains, and anything `security create-keychain` makes."""
+        self.assertEqual(self._round_trip('sha1', 1000), self.DB_KEY)
+
+    def test_every_declared_parameter_set_is_reachable(self):
+        """Nothing may be listed in _KDF_PARAMETERS that the reader cannot open."""
+        for digest, rounds in macos_keychain._KDF_PARAMETERS:  # pylint: disable=protected-access
+            with self.subTest(digest=digest, rounds=rounds):
+                self.assertEqual(self._round_trip(digest, rounds), self.DB_KEY)
+
+    def test_wrong_password_yields_nothing(self):
+        for digest, rounds in macos_keychain._KDF_PARAMETERS:  # pylint: disable=protected-access
+            with self.subTest(digest=digest, rounds=rounds):
+                self.assertIsNone(self._round_trip(digest, rounds, password='not-the-password'))
+
+    def test_undeclared_parameters_are_not_opened(self):
+        """Confirms the tests above pass because of the table, not by chance."""
+        self.assertIsNone(self._round_trip('sha512', 7))
+
+
+@unittest.skipUnless(HAS_SECURITY and HAS_CRYPTO, 'needs macOS `security` and PyCryptodome')
+class TestLiveKeychainRoundTrip(unittest.TestCase):
+    """End-to-end against a keychain macOS itself wrote.
+
+    `security create-keychain` writes the legacy parameter set, so this covers
+    the whole pipeline rather than the current-parameters branch specifically.
+    """
+
+    PASSWORD = 'throwaway-test-password'
+    SERVICE = 'DLEAPP Test Safe Storage'
+    SECRET = 'not-a-real-secret-0123456789'
+
+    @classmethod
+    def setUpClass(cls):
+        cls.workdir = tempfile.mkdtemp()
+        cls.path = os.path.join(cls.workdir, 'dleapp-test.keychain-db')
+        run = lambda *args: subprocess.run(args, check=True, capture_output=True)  # noqa: E731
+        try:
+            run('security', 'create-keychain', '-p', cls.PASSWORD, cls.path)
+            run('security', 'unlock-keychain', '-p', cls.PASSWORD, cls.path)
+            run('security', 'add-generic-password', '-s', cls.SERVICE,
+                '-a', 'DLEAPP Test', '-w', cls.SECRET, cls.path)
+        except (subprocess.CalledProcessError, OSError) as exc:
+            shutil.rmtree(cls.workdir, ignore_errors=True)
+            raise unittest.SkipTest(f'could not build a test keychain: {exc}')
+
+    @classmethod
+    def tearDownClass(cls):
+        subprocess.run(['security', 'delete-keychain', cls.path],
+                       check=False, capture_output=True)
+        shutil.rmtree(cls.workdir, ignore_errors=True)
+
+    def test_recognized_as_a_keychain(self):
+        self.assertTrue(macos_keychain.is_keychain(self.path))
+
+    def test_recovers_the_stored_item(self):
+        self.assertEqual(
+            macos_keychain.find_generic_password(self.path, self.PASSWORD, self.SERVICE),
+            self.SECRET)
+
+    def test_wrong_password_yields_nothing(self):
+        self.assertIsNone(
+            macos_keychain.find_generic_password(self.path, 'wrong-password', self.SERVICE))
+
+    def test_unknown_service_yields_nothing(self):
+        self.assertIsNone(
+            macos_keychain.find_generic_password(self.path, self.PASSWORD, 'No Such Service'))
+
+
+class TestIsKeychain(unittest.TestCase):
+    """is_keychain() gates the whole reader, so it must not guess."""
+
+    def test_rejects_a_non_keychain_file(self):
+        with tempfile.NamedTemporaryFile(suffix='.db') as handle:
+            handle.write(b'SQLite format 3\x00')
+            handle.flush()
+            self.assertFalse(macos_keychain.is_keychain(handle.name))
+
+    def test_rejects_a_missing_file(self):
+        self.assertFalse(macos_keychain.is_keychain('/nonexistent/login.keychain-db'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/macos_keychain.py
+++ b/scripts/macos_keychain.py
@@ -18,8 +18,8 @@ described many times. The recovery is three deterministic steps:
 
 1. Master key = PBKDF2(password, DbBlob salt, 24 bytes), then 3DES-CBC decrypt
    the DbBlob's crypto region with it and the DbBlob IV to get the 24-byte
-   database key. The blob does not say which PBKDF2 parameters were used, so
-   both documented sets are tried (see ``_KDF_PARAMETERS``).
+   database key. The blob does not record which PBKDF2 parameters were used, so
+   the reader carries them (see ``_KDF_PARAMETERS``).
 2. For each symmetric-key record, unwrap its key blob with the database key
    using the CMS 3DES key-unwrap (decrypt with the magic IV, reverse the first
    32 bytes, decrypt again with the blob IV). Index the result by the record's
@@ -27,11 +27,14 @@ described many times. The recovery is three deterministic steps:
 3. A generic-password record carries an SSGP blob whose ``ssgp``+label tag
    selects one unwrapped key; 3DES-CBC decrypt the SSGP body with it.
 
-There is no key searching here. The only thing tried more than once is the pair
-of published PBKDF2 parameter sets at step 1, because the blob does not record
-which one it used; every other value is computed by the documented formula and
-used once. A wrong password fails the padding check under both parameter sets
-and the whole thing returns nothing.
+There is no key searching here: every value is computed by the documented
+formula and used once, for each parameter set the reader knows. A wrong
+password fails the padding check at step 1 and the whole thing returns nothing.
+
+Scope, as tested: this opens keychains written by ``security create-keychain``.
+It does *not* currently open a real ``login.keychain-db``, and why is an open
+question -- see ``_KDF_PARAMETERS``. Callers should treat a ``None`` from
+``find_generic_password`` as "could not open", not as "wrong password".
 """
 
 import hashlib
@@ -61,13 +64,18 @@ _KEY_BLOB_REC_HEADER_SIZE = 132
 _GENERIC_PW_FIELDS = 22                             # uint32 fields before the variable-length data
 _SSGP_HEADER = struct.Struct("> 4s 16s 8s")        # magic, label, iv
 
-# The DbBlob does not record which KDF produced its master key, so both known
-# parameter sets are tried in turn and the one whose 3DES padding validates is
-# the right one. Current macOS releases write SHA-256 with 10000 rounds; a
-# keychain created by older releases (and by `security create-keychain` on any
-# release) uses SHA-1 with 1000. Verified against a live login.keychain-db,
-# which only the SHA-256 set opens.
-_KDF_PARAMETERS = (("sha256", 10000), ("sha1", 1000))
+# The DbBlob does not record which KDF produced its master key, so the reader
+# has to know the parameters. SHA-1 with 1000 rounds is the only set confirmed
+# here: it opens every keychain `security create-keychain` writes.
+#
+# UNRESOLVED: that set does not open a real login.keychain-db, and the reason is
+# not yet known. A sweep once appeared to identify SHA-256/10000, but that
+# result came from a padding check loose enough to accept about 1 wrong key in
+# 256 and is not trusted. Do not add a parameter set here on the strength of a
+# padding hit alone -- confirm it by counting how many of the keychain's
+# symmetric keys the resulting database key unwraps. A correct key opens
+# essentially all of them; a wrong one opens none.
+_KDF_PARAMETERS = (("sha1", 1000),)
 
 
 def crypto_available():

--- a/scripts/macos_keychain.py
+++ b/scripts/macos_keychain.py
@@ -155,7 +155,7 @@ class _Keychain:
 
 
 def _database_key(data, blob_base, password):
-    """Steps 1: password + DbBlob -> 24-byte database key, or None."""
+    """Step 1: password + DbBlob -> 24-byte database key, or None."""
     _common, start_crypto, total_len, _sig, _seq, _params, salt, iv, _bsig = struct.unpack_from(
         "> 8s I I 16s I 8s 20s 8s 20s", data, blob_base)
     ciphertext = data[blob_base + start_crypto:blob_base + total_len]

--- a/scripts/macos_keychain.py
+++ b/scripts/macos_keychain.py
@@ -16,10 +16,10 @@ The format is Apple's ``securityd`` database (``AppleFileDL`` / ``CSSM``),
 documented in Apple's open-source ``securityd`` ``BLOBFORMAT`` and independently
 described many times. The recovery is three deterministic steps:
 
-1. Master key = PBKDF2(password, DbBlob salt, 24 bytes), then 3DES-CBC decrypt
-   the DbBlob's crypto region with it and the DbBlob IV to get the 24-byte
-   database key. The blob does not record which PBKDF2 parameters were used, so
-   the reader carries them (see ``_KDF_PARAMETERS``).
+1. Master key = PBKDF2-HMAC-SHA1(password, DbBlob salt, 1000 iterations, 24
+   bytes), then 3DES-CBC decrypt the DbBlob's crypto region with it and the
+   DbBlob IV to get the 24-byte database key. Those parameters are fixed in
+   securityd and never vary (see ``_KDF_DIGEST``).
 2. For each symmetric-key record, unwrap its key blob with the database key
    using the CMS 3DES key-unwrap (decrypt with the magic IV, reverse the first
    32 bytes, decrypt again with the blob IV). Index the result by the record's
@@ -28,13 +28,15 @@ described many times. The recovery is three deterministic steps:
    selects one unwrapped key; 3DES-CBC decrypt the SSGP body with it.
 
 There is no key searching here: every value is computed by the documented
-formula and used once, for each parameter set the reader knows. A wrong
-password fails the padding check at step 1 and the whole thing returns nothing.
+formula and used once. A wrong password fails the padding check at step 1 and
+the whole thing returns nothing.
 
-Scope, as tested: this opens keychains written by ``security create-keychain``.
-It does *not* currently open a real ``login.keychain-db``, and why is an open
-question -- see ``_KDF_PARAMETERS``. Callers should treat a ``None`` from
-``find_generic_password`` as "could not open", not as "wrong password".
+One caution for callers. A ``None`` means "this password did not open this
+keychain", which is not the same as "the examiner typed the wrong password".
+The login keychain retains its old password when the account password is reset
+through Apple ID or by an administrator, and macOS keeps unlocking it from the
+stashed session key, so a live host gives no hint that the two have diverged.
+Report the failure in those terms rather than as a bad password.
 """
 
 import hashlib
@@ -64,18 +66,26 @@ _KEY_BLOB_REC_HEADER_SIZE = 132
 _GENERIC_PW_FIELDS = 22                             # uint32 fields before the variable-length data
 _SSGP_HEADER = struct.Struct("> 4s 16s 8s")        # magic, label, iv
 
-# The DbBlob does not record which KDF produced its master key, so the reader
-# has to know the parameters. SHA-1 with 1000 rounds is the only set confirmed
-# here: it opens every keychain `security create-keychain` writes.
+# The DbBlob records the PBKDF2 salt but not the digest or the iteration count,
+# so the reader has to carry them. These are fixed, not negotiated: Apple's
+# securityd derives the database master key in DatabaseCryptoCore
+# ::deriveDbMasterKey with CSSM_PKCS5_PBKDF2_PRF_HMAC_SHA1, iterationCount(1000)
+# and a 24-byte key, and none of the three is conditional on anything -- not on
+# the blob version, not on the keychain's age.
 #
-# UNRESOLVED: that set does not open a real login.keychain-db, and the reason is
-# not yet known. A sweep once appeared to identify SHA-256/10000, but that
-# result came from a padding check loose enough to accept about 1 wrong key in
-# 256 and is not trusted. Do not add a parameter set here on the strength of a
-# padding hit alone -- confirm it by counting how many of the keychain's
-# symmetric keys the resulting database key unwraps. A correct key opens
-# essentially all of them; a wrong one opens none.
-_KDF_PARAMETERS = (("sha1", 1000),)
+# Worth knowing, because it looks like a difference that should matter and is
+# not: a real login.keychain-db carries blobVersion 0x200 (version_partition)
+# while anything created today is 0x100. That version gates which *verification*
+# algorithm the blob decode uses, not the key derivation.
+#
+# So a failure here means the password does not open this keychain, and the
+# usual reason is not a typo. A login keychain keeps its old password when the
+# account password is reset through Apple ID or by an administrator, and macOS
+# then unlocks it silently from the stashed session key, so the divergence is
+# invisible until something tries the password directly -- which is exactly what
+# this reader does.
+_KDF_DIGEST = "sha1"
+_KDF_ROUNDS = 1000
 
 
 def crypto_available():
@@ -167,13 +177,12 @@ def _database_key(data, blob_base, password):
     _common, start_crypto, total_len, _sig, _seq, _params, salt, iv, _bsig = struct.unpack_from(
         "> 8s I I 16s I 8s 20s 8s 20s", data, blob_base)
     ciphertext = data[blob_base + start_crypto:blob_base + total_len]
-    secret = password.encode("utf-8")
-    for digest, rounds in _KDF_PARAMETERS:
-        master = hashlib.pbkdf2_hmac(digest, secret, salt, rounds, _KEY_LENGTH)
-        plain = _des3_decrypt(master, iv, ciphertext)
-        if plain and len(plain) >= _KEY_LENGTH:
-            return plain[:_KEY_LENGTH]
-    return None
+    master = hashlib.pbkdf2_hmac(
+        _KDF_DIGEST, password.encode("utf-8"), salt, _KDF_ROUNDS, _KEY_LENGTH)
+    plain = _des3_decrypt(master, iv, ciphertext)
+    if not plain or len(plain) < _KEY_LENGTH:
+        return None
+    return plain[:_KEY_LENGTH]
 
 
 def _unwrap_key(ciphertext, iv, db_key):

--- a/scripts/macos_keychain.py
+++ b/scripts/macos_keychain.py
@@ -16,9 +16,10 @@ The format is Apple's ``securityd`` database (``AppleFileDL`` / ``CSSM``),
 documented in Apple's open-source ``securityd`` ``BLOBFORMAT`` and independently
 described many times. The recovery is three deterministic steps:
 
-1. Master key = PBKDF2-HMAC-SHA1(password, DbBlob salt, 1000 iterations, 24
-   bytes), then 3DES-CBC decrypt the DbBlob's crypto region with it and the
-   DbBlob IV to get the 24-byte database key.
+1. Master key = PBKDF2(password, DbBlob salt, 24 bytes), then 3DES-CBC decrypt
+   the DbBlob's crypto region with it and the DbBlob IV to get the 24-byte
+   database key. The blob does not say which PBKDF2 parameters were used, so
+   both documented sets are tried (see ``_KDF_PARAMETERS``).
 2. For each symmetric-key record, unwrap its key blob with the database key
    using the CMS 3DES key-unwrap (decrypt with the magic IV, reverse the first
    32 bytes, decrypt again with the blob IV). Index the result by the record's
@@ -26,9 +27,11 @@ described many times. The recovery is three deterministic steps:
 3. A generic-password record carries an SSGP blob whose ``ssgp``+label tag
    selects one unwrapped key; 3DES-CBC decrypt the SSGP body with it.
 
-There is no key searching here: every value is computed by the documented
-formula and used once. A wrong password fails the padding check at step 1 and
-the whole thing returns nothing.
+There is no key searching here. The only thing tried more than once is the pair
+of published PBKDF2 parameter sets at step 1, because the blob does not record
+which one it used; every other value is computed by the documented formula and
+used once. A wrong password fails the padding check under both parameter sets
+and the whole thing returns nothing.
 """
 
 import hashlib
@@ -57,6 +60,14 @@ _KEY_BLOB = struct.Struct("> 8s I I 8s")           # commonBlob(magic+ver), star
 _KEY_BLOB_REC_HEADER_SIZE = 132
 _GENERIC_PW_FIELDS = 22                             # uint32 fields before the variable-length data
 _SSGP_HEADER = struct.Struct("> 4s 16s 8s")        # magic, label, iv
+
+# The DbBlob does not record which KDF produced its master key, so both known
+# parameter sets are tried in turn and the one whose 3DES padding validates is
+# the right one. Current macOS releases write SHA-256 with 10000 rounds; a
+# keychain created by older releases (and by `security create-keychain` on any
+# release) uses SHA-1 with 1000. Verified against a live login.keychain-db,
+# which only the SHA-256 set opens.
+_KDF_PARAMETERS = (("sha256", 10000), ("sha1", 1000))
 
 
 def crypto_available():
@@ -147,12 +158,14 @@ def _database_key(data, blob_base, password):
     """Steps 1: password + DbBlob -> 24-byte database key, or None."""
     _common, start_crypto, total_len, _sig, _seq, _params, salt, iv, _bsig = struct.unpack_from(
         "> 8s I I 16s I 8s 20s 8s 20s", data, blob_base)
-    master = hashlib.pbkdf2_hmac("sha1", password.encode("utf-8"), salt, 1000, _KEY_LENGTH)
     ciphertext = data[blob_base + start_crypto:blob_base + total_len]
-    plain = _des3_decrypt(master, iv, ciphertext)
-    if not plain or len(plain) < _KEY_LENGTH:
-        return None
-    return plain[:_KEY_LENGTH]
+    secret = password.encode("utf-8")
+    for digest, rounds in _KDF_PARAMETERS:
+        master = hashlib.pbkdf2_hmac(digest, secret, salt, rounds, _KEY_LENGTH)
+        plain = _des3_decrypt(master, iv, ciphertext)
+        if plain and len(plain) >= _KEY_LENGTH:
+            return plain[:_KEY_LENGTH]
+    return None
 
 
 def _unwrap_key(ciphertext, iv, db_key):

--- a/scripts/signal_desktop.py
+++ b/scripts/signal_desktop.py
@@ -239,9 +239,13 @@ def resolve_database_key(files_found, log=None):
             if key:
                 return key, how
         return None, ("the supplied secret did not unwrap encryptedKey directly"
-                      + (", and did not unlock any login.keychain-db in the extraction"
+                      + (", and did not open any login.keychain-db in the extraction. "
+                         "Note that a login keychain keeps its old password when the account "
+                         "password is reset through Apple ID or by an administrator, and macOS "
+                         "hides the difference by unlocking it from the stashed session key, so "
+                         "the current account password is not always the keychain's password"
                          if keychains else "")
-                      + "; it may be the wrong credential, or belong to a different profile or host")
+                      + "; the credential may also belong to a different profile or host")
 
     if wrapped:
         return None, ("config.json holds an encryptedKey, which is wrapped with the OS credential "


### PR DESCRIPTION
Started as a KDF fix. It is not one: **the original derivation was correct**. What ships here is the evidence, the tests, and a corrected failure message.

Full retraction of the original description is in the comment below; this is the resolved state.

## What was wrong

The reader failed on a real `login.keychain-db`, and I concluded it had a KDF bug. Both pieces of evidence were bad:

- **The oracle was worthless.** `security unlock-keychain -p` against a copy of the login keychain returns success for *any* password, empty string included, because securityd auto-unlocks it from the logged-in session. `set-keychain-password -o` fails the same way. Both re-checked with deliberately wrong passwords.
- **The sweep used the wrong padding rule**, accepting pad bytes 1..16 where a 3DES block only produces 1..8. `MATCH: SHA256 iter=10000` came from that.

## What settled it

- **Control.** The reader opens a keychain freshly created with the same password. Neither the reader nor the password's encoding is at fault.
- **A sweep scored properly.** Every plausible digest x iteration count against the real DbBlob, judged by *how many of its 80 symmetric keys the candidate database key unwraps* rather than by padding. A correct key opens essentially all; a wrong one opens none. SHA-256/10000 passed even strict padding and unwrapped **0 of 80** — the deterministic 1-in-256 coincidence it always was, which is why it reproduced every run.
- **securityd's source.** `DatabaseCryptoCore::deriveDbMasterKey` uses `CSSM_PKCS5_PBKDF2_PRF_HMAC_SHA1`, `iterationCount(1000)`, 24-byte key. None of it conditional.

A real login keychain does carry `blobVersion` `0x200` (`version_partition`) where anything created today carries `0x100`. That looks like it should matter; it gates the verification algorithm in the blob decode, not key derivation. Recorded in a comment so nobody else spends the afternoon on it.

## What actually ships

`_KDF_PARAMETERS` collapses back to `_KDF_DIGEST`/`_KDF_ROUNDS`, so the derivation is byte-for-byte what it was before this branch.

The real defect was in what a failure *says*. The derivation failing means the password does not open that keychain, and the usual cause is not a typo: **a login keychain keeps its old password when the account password is reset through Apple ID or by an administrator**, while macOS goes on unlocking it from the stashed session key. A live host gives no sign the two have diverged — which is precisely why every `security` check accepts anything, and precisely how this got misdiagnosed. Signal's resolver now explains that instead of implying the wrong credential was supplied, and the module docstring tells callers to read a `None` as "could not open", not "wrong password".

## Tests

`admin/test/scripts/test_macos_keychain.py`. Synthetic DbBlobs need no keychain and run on the Linux CI runners; the live round-trip builds a throwaway keychain via `security` and skips where unavailable. `test_other_parameters_are_not_opened` pins SHA-256/10000 as *not* the answer, with the reasoning in its docstring, so the same wrong turn cannot be taken twice.

Full suite 26 passed, lint 10.00/10.

## Not covered

Dead-box recovery from a real login keychain is still unverified end to end, because it needs a password that opens one and the only real keychain to hand does not take the account password. The `0x200` verification-algorithm difference is therefore also untested downstream of step 1.