### PR TITLE
Rename the WhatsApp category from Desktop to Apple

### DIFF
--- a/scripts/artifacts/whatsappCalls.py
+++ b/scripts/artifacts/whatsappCalls.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "creation_date": "2026-07-27",
         "last_update_date": "2026-07-27",
         "requirements": "none",
-        "category": "WhatsApp (Desktop)",
+        "category": "WhatsApp (Apple)",
         "notes": "Outcome Code is the ZOUTCOME value the database holds and is "
                  "reported as the raw integer rather than a guessed label such as "
                  "missed or outgoing. A duration of zero is shown as stored and "
@@ -17,7 +17,7 @@ __artifacts_v2__ = {
         "paths": ('*/CallHistory.sqlite*',),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "phone",
-        "sample_data": {"whatsapp_macos": "WhatsApp Desktop macOS | 212 rows"},
+        "sample_data": {"whatsapp_macos": "WhatsApp macOS | 212 rows"},
     },
 }
 

--- a/scripts/artifacts/whatsappContacts.py
+++ b/scripts/artifacts/whatsappContacts.py
@@ -8,14 +8,14 @@ __artifacts_v2__ = {
         "creation_date": "2026-07-27",
         "last_update_date": "2026-07-27",
         "requirements": "none",
-        "category": "WhatsApp (Desktop)",
+        "category": "WhatsApp (Apple)",
         "notes": "These are the contacts WhatsApp stored, which is not necessarily "
                  "the same set as the device address book. A row can exist for a "
                  "correspondent the account never messaged.",
         "paths": ('*/ContactsV2.sqlite*',),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "user",
-        "sample_data": {"whatsapp_macos": "WhatsApp Desktop macOS | 244 rows"},
+        "sample_data": {"whatsapp_macos": "WhatsApp macOS | 244 rows"},
     },
     "whatsappChatSessions": {
         "name": "WhatsApp Chat Sessions",
@@ -26,13 +26,13 @@ __artifacts_v2__ = {
         "creation_date": "2026-07-27",
         "last_update_date": "2026-07-27",
         "requirements": "none",
-        "category": "WhatsApp (Desktop)",
+        "category": "WhatsApp (Apple)",
         "notes": "The last message text and date are a summary the chat row caches; "
                  "the full messages are in the WhatsApp Messages artifact.",
         "paths": ('*/ChatStorage.sqlite*',),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "list",
-        "sample_data": {"whatsapp_macos": "WhatsApp Desktop macOS | 159 rows"},
+        "sample_data": {"whatsapp_macos": "WhatsApp macOS | 159 rows"},
     },
     "whatsappGroupMembers": {
         "name": "WhatsApp Group Members",
@@ -43,13 +43,13 @@ __artifacts_v2__ = {
         "creation_date": "2026-07-27",
         "last_update_date": "2026-07-27",
         "requirements": "none",
-        "category": "WhatsApp (Desktop)",
+        "category": "WhatsApp (Apple)",
         "notes": "A member row reflects the membership WhatsApp last recorded for "
                  "the group, not necessarily the membership at any earlier time.",
         "paths": ('*/ChatStorage.sqlite*',),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "users",
-        "sample_data": {"whatsapp_macos": "WhatsApp Desktop macOS | 1033 rows"},
+        "sample_data": {"whatsapp_macos": "WhatsApp macOS | 1033 rows"},
     },
     "whatsappBlocked": {
         "name": "WhatsApp Blocked Contacts",
@@ -59,13 +59,13 @@ __artifacts_v2__ = {
         "creation_date": "2026-07-27",
         "last_update_date": "2026-07-27",
         "requirements": "none",
-        "category": "WhatsApp (Desktop)",
+        "category": "WhatsApp (Apple)",
         "notes": "The table stores the JID only. A matching name, where shown, is "
                  "looked up from the push-name and chat tables in the same database.",
         "paths": ('*/ChatStorage.sqlite*',),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "slash",
-        "sample_data": {"whatsapp_macos": "WhatsApp Desktop macOS | 45 rows"},
+        "sample_data": {"whatsapp_macos": "WhatsApp macOS | 45 rows"},
     },
     "whatsappPushNames": {
         "name": "WhatsApp Push Names",
@@ -76,14 +76,14 @@ __artifacts_v2__ = {
         "creation_date": "2026-07-27",
         "last_update_date": "2026-07-27",
         "requirements": "none",
-        "category": "WhatsApp (Desktop)",
+        "category": "WhatsApp (Apple)",
         "notes": "A push name is chosen by the correspondent, not by the account "
                  "holder or their address book, so it can differ from a saved "
                  "contact name and is not a verified identity.",
         "paths": ('*/ChatStorage.sqlite*',),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "tag",
-        "sample_data": {"whatsapp_macos": "WhatsApp Desktop macOS | 493 rows"},
+        "sample_data": {"whatsapp_macos": "WhatsApp macOS | 493 rows"},
     },
 }
 

--- a/scripts/artifacts/whatsappMedia.py
+++ b/scripts/artifacts/whatsappMedia.py
@@ -10,7 +10,7 @@ __artifacts_v2__ = {
         "creation_date": "2026-07-27",
         "last_update_date": "2026-07-27",
         "requirements": "none",
-        "category": "WhatsApp (Desktop)",
+        "category": "WhatsApp (Apple)",
         "notes": "The media kind shown is derived from the stored file's extension, "
                  "so it reflects the file itself. Latitude and longitude are shown "
                  "only when the row holds a non-zero coordinate. A row can list a "
@@ -22,7 +22,7 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "image",
-        "sample_data": {"whatsapp_macos": "WhatsApp Desktop macOS | 43910 rows"},
+        "sample_data": {"whatsapp_macos": "WhatsApp macOS | 43910 rows"},
     },
 }
 

--- a/scripts/artifacts/whatsappMessages.py
+++ b/scripts/artifacts/whatsappMessages.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "creation_date": "2026-07-27",
         "last_update_date": "2026-07-27",
         "requirements": "none",
-        "category": "WhatsApp (Desktop)",
+        "category": "WhatsApp (Apple)",
         "notes": "Direction is taken from the ZISFROMME column: a set flag is "
                  "reported as Outgoing, a clear flag as Incoming. Type Code is the "
                  "ZMESSAGETYPE value the database stores and is left as the integer "
@@ -27,7 +27,7 @@ __artifacts_v2__ = {
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "message-circle",
         "sample_data": {
-            "whatsapp_macos": "WhatsApp Desktop macOS | 45363 rows",
+            "whatsapp_macos": "WhatsApp macOS | 45363 rows",
         },
         "data_views": {
             "conversation": {


### PR DESCRIPTION
The WhatsApp parsers read the Apple Core Data schema (`ChatStorage.sqlite` and siblings) shared by the native macOS app and iOS. The Windows WhatsApp app stores its data in a different format these readers do not touch, so **"WhatsApp (Desktop)" wrongly implied Windows coverage**.

Renames the category on all eight artifacts to **"WhatsApp (Apple)"** — accurate for macOS and iOS, and correctly excluding Windows. The corpus `sample_data` labels drop "Desktop" to match.

No logic change. Lint 10/10, sample_data 0 errors, 17 tests pass.