### PR TITLE
Rename the Signal category from Desktop to macOS

### DIFF
--- a/scripts/artifacts/signalAccount.py
+++ b/scripts/artifacts/signalAccount.py
@@ -13,7 +13,7 @@ __artifacts_v2__ = {
         "last_update_date": "2026-07-26",
         "requirements": "PyCryptodome; the Signal database credential for the "
                         "account fields",
-        "category": "Signal (Desktop)",
+        "category": "Signal (macOS)",
         "notes": "Key material is reported as present or absent, never printed: "
                  "the store also holds the account password, master key, "
                  "profile key and storage keys, which would let the account be "

--- a/scripts/artifacts/signalContacts.py
+++ b/scripts/artifacts/signalContacts.py
@@ -9,7 +9,7 @@ __artifacts_v2__ = {
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
         "requirements": "PyCryptodome; the Signal database credential",
-        "category": "Signal (Desktop)",
+        "category": "Signal (macOS)",
         "notes": "A conversation exists here once Signal has learned of the "
                  "account, which includes accounts that were never messaged "
                  "from this device. The message count distinguishes those.",
@@ -35,7 +35,7 @@ __artifacts_v2__ = {
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
         "requirements": "PyCryptodome; the Signal database credential",
-        "category": "Signal (Desktop)",
+        "category": "Signal (macOS)",
         "notes": "Signal Desktop records calls it observed. A call placed or "
                  "answered on a phone linked to the same account may not appear "
                  "here, so an absent call is not evidence no call took place.",
@@ -63,7 +63,7 @@ __artifacts_v2__ = {
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
         "requirements": "PyCryptodome; the Signal database credential",
-        "category": "Signal (Desktop)",
+        "category": "Signal (macOS)",
         "notes": "These records show cryptographic contact at the protocol "
                  "level, which can name accounts that no longer appear in any "
                  "message. Key material itself is not reported.",

--- a/scripts/artifacts/signalMessages.py
+++ b/scripts/artifacts/signalMessages.py
@@ -11,7 +11,7 @@ __artifacts_v2__ = {
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
         "requirements": "PyCryptodome; the Signal database credential",
-        "category": "Signal (Desktop)",
+        "category": "Signal (macOS)",
         "notes": "Message bodies come from the messages table. A row with an "
                  "empty body is not necessarily an empty message: it may be a "
                  "view-once message that was opened, a message whose body was "
@@ -55,7 +55,7 @@ __artifacts_v2__ = {
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
         "requirements": "PyCryptodome; the Signal database credential",
-        "category": "Signal (Desktop)",
+        "category": "Signal (macOS)",
         "notes": "Signal pads a stored attachment with zeroes to hide its true "
                  "length, so the file is truncated to the size the database "
                  "records. The Verified column reports whether the recovered "
@@ -82,7 +82,7 @@ __artifacts_v2__ = {
         "creation_date": "2026-07-26",
         "last_update_date": "2026-07-26",
         "requirements": "PyCryptodome; the Signal database credential",
-        "category": "Signal (Desktop)",
+        "category": "Signal (macOS)",
         "notes": "A reaction is stored separately from the message it targets, "
                  "so it survives here even where the message body is empty.",
         "paths": (


### PR DESCRIPTION
Applies the same accuracy standard used for `WhatsApp (Apple)`: the category should state **verified current support, not potential**.

Signal was built and tested only against a real macOS profile (the `signal_macos` corpus, row counts validated). No Linux or Windows extraction has been run through it, and on Windows the `encryptedKey` path does not work at all (DPAPI, not implemented — see #30). "Desktop" implied cross-platform coverage that isn't demonstrated, so this changes it to **`Signal (macOS)`**.

macOS rather than Apple, because Signal's macOS build is the Electron desktop app with no iOS counterpart sharing its format (that distinction is what made "Apple" right for WhatsApp).

The parsing itself stays platform-independent, so the label can widen once a Windows or Linux profile is actually tested. No logic change; lint 10/10, sample_data 0 errors, 17 tests pass.