### PR TITLE
Set version to 2026.2.0 to match the shipped release

### DIFF
--- a/scripts/version_info.py
+++ b/scripts/version_info.py
@@ -5,7 +5,7 @@ Leave blank if not available
 """
 
 leapp_name = 'DLEAPP'
-dleapp_version = '2.3.0-dev.0'
+dleapp_version = '2026.2.0'
 
 dleapp_contributors = [
     ['Alexis Brignoni', 'https://abrignoni.com', '@AlexisBrignoni', 'https://github.com/abrignoni'],


### PR DESCRIPTION
`scripts/version_info.py` was still on the old 2.x scheme (`2.3.0-dev.0`) and never migrated to the calendar versioning the rest of the family uses. The GUI title bar, HTML reports, and the recent-run history were all reporting a version that does not match the v2026.2.0 release.

**Change:** `dleapp_version = '2.3.0-dev.0'` becomes `dleapp_version = '2026.2.0'`

**Why this value:** ALEAPP, RLEAPP, and VLEAPP all carry their released version in code (all three are at `2026.2.0`). iLEAPP sits at `2026.3.0-dev.0` only because it has already released 2026.2.1 and opened the next dev cycle. DLEAPP just shipped 2026.2.0 and has not started a new cycle, so the released value is correct here.

Verified the module imports and reads back `DLEAPP v2026.2.0`, and no `2.3.0` references remain in the tracked tree.

Note for the record: the shipped v2026.2.0 tag itself contains `2.3.0-dev.0`, so binaries built from that tag still report the old string. This fix applies going forward.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>