### PR TITLE
GUI: Select All / Deselect All act on the filtered list

### DIFF
--- a/dleappGUI.py
+++ b/dleappGUI.py
@@ -81,18 +81,28 @@ def get_selected_modules():
     return selected_modules
 
 
+def module_matches_filter(module_infos, filter_term=None):
+    '''Return True when a module matches the active filter, meaning it is one of the modules
+    currently shown in the list. An empty filter matches every module.'''
+    if filter_term is None:
+        filter_term = modules_filter_var.get().lower()
+    return filter_term in f"{module_infos[0]} {module_infos[1]}".lower()
+
+
 def select_all():
-    '''Select all modules in the list of available modules and execute get_selected_modules'''
+    '''Select the modules currently shown in the list and execute get_selected_modules'''
     for module_infos in mlist.values():
-        module_infos[-1].set(True)
+        if module_matches_filter(module_infos):
+            module_infos[-1].set(True)
 
     get_selected_modules()
 
 
 def deselect_all():
-    '''Unselect all modules in the list of available modules and execute get_selected_modules'''
+    '''Unselect the modules currently shown in the list and execute get_selected_modules'''
     for module_infos in mlist.values():
-        module_infos[-1].set(False)
+        if module_matches_filter(module_infos):
+            module_infos[-1].set(False)
 
     get_selected_modules()
 
@@ -104,8 +114,7 @@ def filter_modules(*args):
     mlist_text.delete('0.0', tk.END)
 
     for artifact_name, module_infos in mlist.items():
-        filter_modules_info = f"{module_infos[0]} {module_infos[1]}".lower()
-        if filter_term in filter_modules_info:
+        if module_matches_filter(module_infos, filter_term):
             cb = tk.Checkbutton(mlist_text, name=f'mcb_{artifact_name}',
                                 text=f'{module_infos[0]} [{module_infos[1]} | {module_infos[2]}.py]',
                                 variable=module_infos[-1], onvalue=True, offvalue=False, command=get_selected_modules)


### PR DESCRIPTION
When a filter is applied the module list only shows matching modules, but **Select All** / **Deselect All** still walked the entire list — so they toggled modules that were not on screen. Filtering to a term and pressing **Select All** selected *every* module in the tool.

Both buttons now act on the modules matching the active filter (i.e. exactly what is displayed). The match test used by `filter_modules` is factored into a shared `module_matches_filter()` so the buttons and the list can never disagree about what counts as visible.

**No regression when unfiltered:** an empty filter term matches every module, so `Select All` with no filter behaves exactly as before. Selections made under one filter are left untouched when the filter changes.

Verified: compiles; behavioral test covers unfiltered select/deselect, filtered select (only matching modules toggled), persistence across filter changes, and filtered deselect; **0 new pylint warnings** (30 before, 30 after).

Completes the same fix across the family — iLEAPP #1803, ALEAPP #997, RLEAPP #383, VLEAPP #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)