### PR TITLE
Add Roblox macOS forensic artifacts

### DIFF
--- a/scripts/artifacts/robloxAccount.py
+++ b/scripts/artifacts/robloxAccount.py
@@ -1,0 +1,179 @@
+__artifacts_v2__ = {
+    "robloxAccount": {
+        "name": "Roblox Account & Application",
+        "description": "Account identity and application state retained by Roblox "
+                       "Desktop, including the user and display names, numeric user "
+                       "ID, age bracket, locale, country, installation identifiers, "
+                       "theme, subscription state and installed client version.",
+        "author": "@AlexisBrignoni, Codex",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Roblox (macOS)",
+        "notes": "Values are reported verbatim for evidentiary analysis, including "
+                 "PlayerHydrationBlob and PlayerHydrationSignature. Output must be "
+                 "handled as credential-bearing evidence. Timestamps are UTC.",
+        "paths": (
+            "*/Library/Roblox/LocalStorage/appStorage.json",
+            "*/Library/Preferences/com.roblox.RobloxPlayer.plist",
+            "*/Library/Preferences/com.roblox.RobloxPlayerChannel.plist",
+        ),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "user",
+        "sample_data": {
+            "roblox_macos": "Roblox 0.732.0.7321040 macOS | 28 rows",
+        },
+    },
+    "robloxSettings": {
+        "name": "Roblox Player Settings",
+        "description": "Roblox player preferences from GlobalBasicSettings XML, "
+                       "including chat, privacy-adjacent, accessibility, graphics, "
+                       "audio, input and window settings.",
+        "author": "@AlexisBrignoni, Codex",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Roblox (macOS)",
+        "notes": "Compound XML values such as vectors are flattened into a compact "
+                 "name=value representation.",
+        "paths": ("*/Library/Roblox/GlobalBasicSettings_*.xml",),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "settings",
+        "sample_data": {
+            "roblox_macos": "Roblox 0.732.0.7321040 macOS | 74 rows",
+        },
+    },
+}
+
+import json
+import os
+import plistlib
+import xml.etree.ElementTree as ET
+
+from scripts.ilapfuncs import artifact_processor, logfunc
+from scripts.roblox import compact_value, epoch_datetime, read_json
+
+
+_ACCOUNT_ITEMS = {
+    "UserId": "User ID",
+    "Username": "Username",
+    "DisplayName": "Display Name",
+    "CountryCode": "Country Code",
+    "RobloxLocaleId": "Roblox Locale",
+    "GameLocaleId": "Game Locale",
+    "Membership": "Membership",
+    "HasRobloxSubscription": "Has Roblox Subscription",
+    "IsUnder13": "Under 13",
+    "AppInstallationId": "App Installation ID",
+    "BrowserTrackerId": "Browser Tracker ID",
+    "WebViewUserAgent": "WebView User Agent",
+    "AuthenticatedTheme": "Authenticated Theme",
+    "DeviceLevelTheme": "Device Theme",
+    "PreviousAccountsList": "Previous Accounts",
+    "UpdateControllerCacheChannel": "Update Channel",
+    "AccountBlob": "Account Blob",
+    "PlayerHydrationBlob": "Player Hydration Blob",
+    "PlayerHydrationSignature": "Player Hydration Signature",
+}
+
+
+def _add(data, prop, value, path, context):
+    if value not in (None, "", [], {}):
+        data.append((prop, compact_value(value), context.get_relative_path(path)))
+
+
+@artifact_processor
+def robloxAccount(context):
+    data_headers = ("Property", "Value", "Source File")
+    data_list = []
+    source_paths = []
+
+    for file_found in map(str, context.get_files_found()):
+        name = os.path.basename(file_found)
+        if name == "appStorage.json":
+            payload = read_json(file_found)
+            if not isinstance(payload, dict):
+                continue
+            source_paths.append(file_found)
+            for key, label in _ACCOUNT_ITEMS.items():
+                _add(data_list, label, payload.get(key), file_found, context)
+
+            hydration = payload.get("PlayerHydrationBlob")
+            try:
+                hydration = json.loads(hydration) if hydration else {}
+            except (TypeError, ValueError):
+                hydration = {}
+            if isinstance(hydration, dict):
+                for key, label in (
+                        ("lastPerformed", "Account Hydration Time"),
+                        ("ageBracket", "Age Bracket"),
+                        ("gender", "Gender"),
+                        ("platform", "Platform")):
+                    value = hydration.get(key)
+                    if key == "lastPerformed":
+                        value = epoch_datetime(value)
+                    _add(data_list, label, value, file_found, context)
+
+            update = payload.get("UpdateControllerCacheJsonPayload")
+            try:
+                update = json.loads(update) if update else {}
+            except (TypeError, ValueError):
+                update = {}
+            if isinstance(update, dict):
+                _add(data_list, "Client Version", update.get("version"),
+                     file_found, context)
+                _add(data_list, "Client Version Upload",
+                     update.get("clientVersionUpload"), file_found, context)
+            _add(data_list, "Update Cache Time",
+                 epoch_datetime(payload.get("UpdateControllerCacheTimestamp")),
+                 file_found, context)
+
+        elif name.endswith(".plist"):
+            try:
+                with open(file_found, "rb") as handle:
+                    payload = plistlib.load(handle)
+            except (OSError, plistlib.InvalidFileException):
+                continue
+            source_paths.append(file_found)
+            for key, value in payload.items():
+                label = {
+                    "DeviceIdV2": "Roblox Device ID",
+                    "NSWindow Frame Main Window": "Main Window Frame",
+                    "www.roblox.com": "Website Update Channel",
+                }.get(key)
+                if label:
+                    _add(data_list, label, value, file_found, context)
+
+    logfunc(f"Roblox Account & Application: {len(data_list)} property value(s).")
+    return data_headers, data_list, "\n".join(source_paths)
+
+
+def _xml_value(element):
+    if len(element):
+        return ", ".join(
+            f"{child.tag}={child.text or ''}" for child in element)
+    return element.text or ""
+
+
+@artifact_processor
+def robloxSettings(context):
+    data_headers = ("Setting", "Value", "Value Type", "Source File")
+    data_list = []
+    source_paths = []
+    for file_found in map(str, context.get_files_found()):
+        try:
+            root = ET.parse(file_found).getroot()
+        except (OSError, ET.ParseError) as ex:
+            logfunc(f"Roblox settings: could not parse '{file_found}': {ex}")
+            continue
+        source_paths.append(file_found)
+        for properties in root.findall(".//Properties"):
+            for item in properties:
+                name = item.attrib.get("name")
+                if name:
+                    data_list.append((
+                        name, _xml_value(item), item.tag,
+                        context.get_relative_path(file_found),
+                    ))
+    logfunc(f"Roblox Player Settings: {len(data_list)} setting(s).")
+    return data_headers, data_list, "\n".join(source_paths)

--- a/scripts/artifacts/robloxActivity.py
+++ b/scripts/artifacts/robloxActivity.py
@@ -1,0 +1,223 @@
+__artifacts_v2__ = {
+    "robloxSessionState": {
+        "name": "Roblox Session State",
+        "description": "The most recently persisted Roblox application or play "
+                       "session, with launch, session and synchronization times, "
+                       "account and experience identifiers, server address, client "
+                       "version, session IDs and result state.",
+        "author": "@AlexisBrignoni, Codex",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Roblox (macOS)",
+        "notes": "memProfStorage is rolling state and generally describes the most "
+                 "recent session only. Unix timestamps are reported in UTC.",
+        "paths": ("*/Library/Roblox/LocalStorage/memProfStorage*.json",),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "clock",
+        "sample_data": {
+            "roblox_macos": "Roblox 0.732.0.7321040 macOS | 1 row",
+        },
+    },
+    "robloxPresence": {
+        "name": "Roblox Presence",
+        "description": "Recently retained Roblox user-presence state from WebKit "
+                       "Local Storage, identifying users, their presence type and "
+                       "last reported location.",
+        "author": "@AlexisBrignoni, Codex",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Roblox (macOS)",
+        "notes": "Presence type values are preserved numerically because Roblox may "
+                 "change their interpretation. Timestamps are UTC.",
+        "paths": (
+            "*/Library/WebKit/com.roblox.RobloxPlayer/WebsiteData/*/*/*/"
+            "LocalStorage/localstorage.sqlite3",
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "users",
+        "sample_data": {
+            "roblox_macos": "Roblox 0.732.0.7321040 macOS | 2 rows",
+        },
+    },
+    "robloxNotifications": {
+        "name": "Roblox Real-Time Notifications",
+        "description": "The latest real-time notification retained in Roblox "
+                       "WebKit Local Storage. Chat notifications can preserve the "
+                       "sender, conversation ID and message text shown to the user.",
+        "author": "@AlexisBrignoni, Codex",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Roblox (macOS)",
+        "notes": "This key is overwritten as notifications arrive, so it is a "
+                 "latest-state artifact rather than a complete notification history.",
+        "paths": (
+            "*/Library/WebKit/com.roblox.RobloxPlayer/WebsiteData/*/*/*/"
+            "LocalStorage/localstorage.sqlite3",
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "bell",
+        "sample_data": {
+            "roblox_macos": "Roblox 0.732.0.7321040 macOS | 1 row",
+        },
+    },
+}
+
+import json
+
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
+from scripts.roblox import decode_webkit_value, epoch_datetime, read_json
+
+
+@artifact_processor
+def robloxSessionState(context):
+    data_headers = (
+        ("Session Start", "datetime"), ("Last Sync", "datetime"),
+        ("Application Launch", "datetime"), "Session Type", "User ID",
+        "Place ID", "Universe ID", "Game Instance ID", "Server Address",
+        "Server Port", "Play Session ID", "App Session ID", "Session Result",
+        "Session Success", "Application Version", "Engine Version", "Channel",
+        "Device", "OS", "Source File",
+    )
+    data_list = []
+    source_paths = []
+    for file_found in map(str, context.get_files_found()):
+        payload = read_json(file_found)
+        if not isinstance(payload, dict):
+            continue
+        source_paths.append(file_found)
+        data_list.append((
+            epoch_datetime(payload.get("SessionStartTime")
+                           or payload.get("AppSessionStartTime")),
+            epoch_datetime(payload.get("SyncTime")),
+            epoch_datetime(payload.get("LaunchTimestamp")),
+            payload.get("SessionType", ""),
+            payload.get("DebugUserId") or payload.get("UserId", ""),
+            payload.get("LastPlaceId", ""),
+            payload.get("UniverseId", ""),
+            payload.get("GameInstanceId", ""),
+            payload.get("ServerIp", ""),
+            payload.get("ServerPort", ""),
+            payload.get("PlaySessionId", ""),
+            payload.get("AppSessionIdL0", ""),
+            payload.get("SessionResultV2") or payload.get("SessionResult", ""),
+            payload.get("SessionSuccess", ""),
+            payload.get("AppVersion", ""),
+            payload.get("EngineVersion", ""),
+            payload.get("Channel", ""),
+            payload.get("Device", ""),
+            f"{payload.get('OSType', '')} {payload.get('OSVersion', '')}".strip(),
+            context.get_relative_path(file_found),
+        ))
+    logfunc(f"Roblox Session State: {len(data_list)} session state record(s).")
+    return data_headers, data_list, "\n".join(source_paths)
+
+
+def _local_storage_items(path):
+    connection = open_sqlite_db_readonly(path)
+    if not connection:
+        return []
+    try:
+        rows = connection.execute("SELECT key, value FROM ItemTable").fetchall()
+    except Exception as ex:  # pylint: disable=broad-exception-caught
+        logfunc(f"Roblox Local Storage: could not read '{path}': {ex}")
+        rows = []
+    connection.close()
+    return rows
+
+
+@artifact_processor
+def robloxPresence(context):
+    data_headers = (
+        ("Last Updated", "datetime"), "User ID", "Presence Type",
+        "Last Location", "Source File",
+    )
+    data_list = []
+    source_paths = []
+    for file_found in map(str, context.get_files_found()):
+        for key, value in _local_storage_items(file_found):
+            if key != "PresenceData":
+                continue
+            try:
+                payload = json.loads(decode_webkit_value(value))
+            except (TypeError, ValueError):
+                continue
+            source_paths.append(file_found)
+            for stored_user_id, entry in payload.items():
+                if not isinstance(entry, dict):
+                    continue
+                presence = entry.get("data") or {}
+                data_list.append((
+                    epoch_datetime(entry.get("lastUpdated")),
+                    presence.get("userId") or stored_user_id,
+                    presence.get("userPresenceType", ""),
+                    presence.get("lastLocation", ""),
+                    context.get_relative_path(file_found),
+                ))
+    data_list.sort(key=lambda row: row[0] if row[0] else epoch_datetime(1))
+    logfunc(f"Roblox Presence: {len(data_list)} presence record(s).")
+    return data_headers, data_list, "\n".join(source_paths)
+
+
+def _notification_fields(payload):
+    detail = payload.get("detail") or {}
+    content = detail.get("content") or {}
+    state_name = content.get("currentState") or "default"
+    state = (content.get("states") or {}).get(state_name) or {}
+    sender_id = (content.get("clientEventsPayload") or {}).get("sender_id", "")
+    title = text = conversation_id = ""
+    for visual in state.get("visualItems") or []:
+        body = visual.get("textBody") if isinstance(visual, dict) else None
+        if body:
+            title = (body.get("title") or {}).get("text", "")
+            text = (body.get("label") or {}).get("text", "")
+            try:
+                params = json.loads(body.get("actionEventParams") or "{}")
+                conversation_id = params.get("conversationId", "")
+            except (TypeError, ValueError):
+                pass
+        thumb = visual.get("thumbnail") if isinstance(visual, dict) else None
+        if thumb and not sender_id:
+            sender_id = thumb.get("id", "")
+    return detail, content, sender_id, title, text, conversation_id
+
+
+@artifact_processor
+def robloxNotifications(context):
+    data_headers = (
+        ("Delivered", "datetime"), "Notification Type", "Namespace", "Title",
+        "Text", "Sender User ID", "Conversation ID", "Notification ID",
+        "Priority", "Sequence Number", "Realtime Message ID", "Source File",
+    )
+    data_list = []
+    source_paths = []
+    for file_found in map(str, context.get_files_found()):
+        for key, value in _local_storage_items(file_found):
+            if key != "Roblox.RealTime.Events.Notification":
+                continue
+            try:
+                payload = json.loads(decode_webkit_value(value))
+            except (TypeError, ValueError):
+                continue
+            detail, content, sender, title, text, conversation = \
+                _notification_fields(payload)
+            source_paths.append(file_found)
+            data_list.append((
+                epoch_datetime(detail.get("deliverTimestamp")),
+                content.get("notificationType", ""),
+                payload.get("namespace", ""),
+                title,
+                text,
+                sender,
+                conversation,
+                content.get("id", ""),
+                content.get("priority", ""),
+                detail.get("SequenceNumber")
+                or payload.get("namespaceSequenceNumber", ""),
+                detail.get("RealtimeMessageIdentifier", ""),
+                context.get_relative_path(file_found),
+            ))
+    logfunc(f"Roblox Real-Time Notifications: {len(data_list)} notification(s).")
+    return data_headers, data_list, "\n".join(source_paths)

--- a/scripts/artifacts/robloxCookies.py
+++ b/scripts/artifacts/robloxCookies.py
@@ -1,0 +1,152 @@
+__artifacts_v2__ = {
+    "robloxCookies": {
+        "name": "Roblox Cookies",
+        "description": "Cookies from Roblox Desktop's macOS binary cookie store, "
+                       "including domain, name, path, creation, expiry, last-access "
+                       "time, flags and the complete stored value.",
+        "author": "@AlexisBrignoni, Codex",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Roblox (macOS)",
+        "notes": "All values are reported verbatim for evidentiary analysis. The "
+                 "output can contain live authentication, anti-bot, "
+                 "identity-verification and session credentials.",
+        "paths": (
+            "*/Library/HTTPStorages/com.roblox.RobloxPlayer.binarycookies",
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "key",
+        "sample_data": {
+            "roblox_macos": "Roblox 0.732.0.7321040 macOS | 17 rows",
+        },
+    },
+}
+
+import plistlib
+import struct
+from datetime import datetime, timezone
+
+from scripts.ilapfuncs import artifact_processor, logfunc
+
+
+_APPLE_EPOCH = 978307200
+def _read_cstring(record, offset):
+    if offset <= 0 or offset >= len(record):
+        return ""
+    end = record.find(b"\x00", offset)
+    if end < 0:
+        end = len(record)
+    return record[offset:end].decode("utf-8", "replace")
+
+
+def _apple_datetime(value):
+    try:
+        return datetime.fromtimestamp(float(value) + _APPLE_EPOCH,
+                                      tz=timezone.utc)
+    except (OSError, OverflowError, TypeError, ValueError):
+        return ""
+
+
+def _parse_cookie(record):
+    if len(record) < 56:
+        return None
+    try:
+        size = struct.unpack_from("<I", record, 0)[0]
+        flags = struct.unpack_from("<I", record, 8)[0]
+        domain_off, name_off, path_off, value_off = struct.unpack_from(
+            "<IIII", record, 16)
+        expires, created = struct.unpack_from("<dd", record, 40)
+    except struct.error:
+        return None
+    if size > len(record) or min(domain_off, name_off, path_off, value_off) < 0:
+        return None
+    domain = _read_cstring(record, domain_off)
+    name = _read_cstring(record, name_off)
+    path = _read_cstring(record, path_off)
+    value = _read_cstring(record, value_off)
+    accessed = ""
+    plist_offset = record.find(b"bplist00")
+    if plist_offset >= 0:
+        try:
+            metadata = plistlib.loads(record[plist_offset:])
+            accessed = _apple_datetime(metadata.get("AccessTime"))
+        except (plistlib.InvalidFileException, ValueError, TypeError):
+            pass
+    return {
+        "created": _apple_datetime(created),
+        "accessed": accessed,
+        "expires": _apple_datetime(expires),
+        "domain": domain,
+        "name": name,
+        "path": path,
+        "value": value,
+        "value_length": len(value),
+        "flags": f"0x{flags:08X}",
+    }
+
+
+def _parse_binary_cookies(path):
+    try:
+        with open(path, "rb") as handle:
+            data = handle.read()
+    except OSError:
+        return []
+    if len(data) < 8 or data[:4] != b"cook":
+        return []
+    try:
+        page_count = struct.unpack_from(">I", data, 4)[0]
+        page_sizes = struct.unpack_from(
+            ">" + ("I" * page_count), data, 8)
+    except struct.error:
+        return []
+    position = 8 + (4 * page_count)
+    cookies = []
+    for page_size in page_sizes:
+        page = data[position:position + page_size]
+        position += page_size
+        if len(page) < 8:
+            continue
+        try:
+            cookie_count = struct.unpack_from("<I", page, 4)[0]
+            offsets = struct.unpack_from(
+                "<" + ("I" * cookie_count), page, 8)
+        except struct.error:
+            continue
+        for offset in offsets:
+            if offset + 4 > len(page):
+                continue
+            try:
+                size = struct.unpack_from("<I", page, offset)[0]
+            except struct.error:
+                continue
+            if size < 56 or offset + size > len(page):
+                continue
+            cookie = _parse_cookie(page[offset:offset + size])
+            if cookie:
+                cookies.append(cookie)
+    return cookies
+
+
+@artifact_processor
+def robloxCookies(context):
+    data_headers = (
+        ("Created", "datetime"), ("Last Access", "datetime"),
+        ("Expires", "datetime"), "Domain", "Name", "Path", "Value",
+        "Value Length", "Flags", "Source File",
+    )
+    data_list = []
+    source_paths = []
+    for file_found in map(str, context.get_files_found()):
+        cookies = _parse_binary_cookies(file_found)
+        if cookies:
+            source_paths.append(file_found)
+        for cookie in cookies:
+            data_list.append((
+                cookie["created"], cookie["accessed"], cookie["expires"],
+                cookie["domain"], cookie["name"], cookie["path"],
+                cookie["value"], cookie["value_length"], cookie["flags"],
+                context.get_relative_path(file_found),
+            ))
+    logfunc(f"Roblox Cookies: {len(data_list)} cookie(s).")
+    return data_headers, data_list, "\n".join(source_paths)

--- a/scripts/artifacts/robloxLogs.py
+++ b/scripts/artifacts/robloxLogs.py
@@ -1,0 +1,262 @@
+__artifacts_v2__ = {
+    "robloxGameJoins": {
+        "name": "Roblox Game Joins",
+        "description": "Roblox experience joins reconstructed from Player logs, "
+                       "including UTC time, place and universe IDs, game instance, "
+                       "account, join attempt, party, join origin, and the UDMUX and "
+                       "RCC server addresses recorded by the client.",
+        "author": "@AlexisBrignoni, Codex",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Roblox (macOS)",
+        "notes": "UDMUX and RCC labels follow the source log. In the tested corpus "
+                 "UDMUX was public-routable and RCC used private address space, but "
+                 "that relationship is an observation rather than a guaranteed "
+                 "Roblox format rule. Log rotation limits historical coverage.",
+        "paths": ("*/Library/Logs/Roblox/*_Player_*.log",),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "log-in",
+        "sample_data": {
+            "roblox_macos": "Roblox 0.732.0.7321040 macOS | 3 rows",
+        },
+    },
+    "robloxHttpActivity": {
+        "name": "Roblox HTTP Activity",
+        "description": "HTTP responses and failures recorded by Roblox Player, "
+                       "showing the log-event time, destination URL and host, status, "
+                       "server IP, elapsed time, body size and retry state.",
+        "author": "@AlexisBrignoni, Codex",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Roblox (macOS)",
+        "notes": "URLs and query parameters are reported verbatim for evidentiary "
+                 "analysis and may contain usable credentials. Player-log URLs form "
+                 "a partial activity record, not browser history.",
+        "paths": ("*/Library/Logs/Roblox/*_Player_*.log",),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "globe",
+        "sample_data": {
+            "roblox_macos": "Roblox 0.732.0.7321040 macOS | 71 rows",
+        },
+    },
+    "robloxPlayerLog": {
+        "name": "Roblox Player Log",
+        "description": "All structured Roblox Player log events with their UTC "
+                       "timestamp, process-relative elapsed time, severity, logging "
+                       "component and message.",
+        "author": "@AlexisBrignoni, Codex",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Roblox (macOS)",
+        "notes": "Long messages are limited to 10,000 characters. The first "
+                 "untimestamped policy line and multiline continuations are omitted.",
+        "paths": ("*/Library/Logs/Roblox/*_Player_*.log",),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "file-text",
+        "sample_data": {
+            "roblox_macos": "Roblox 0.732.0.7321040 macOS | 2249 rows",
+        },
+    },
+}
+
+import os
+import re
+from datetime import datetime, timezone
+from urllib.parse import urlsplit
+
+from scripts.ilapfuncs import artifact_processor, logfunc
+from scripts.roblox import iso_datetime
+
+
+_LINE_RE = re.compile(
+    r"^(?P<timestamp>\d{4}-\d{2}-\d{2}T[^,]+),"
+    r"(?P<elapsed>[^,]+),(?P<thread>[^,]+),(?P<level>\d+)"
+    r"(?:,(?P<severity>\w+))? \[(?P<component>[^\]]+)\] (?P<message>.*)$")
+_JOIN_RE = re.compile(
+    r"! Joining game ['\"](?P<job>[^'\"]+)['\"] place "
+    r"(?P<place>\d+) at (?P<rcc>[0-9a-fA-F:.]+)")
+_LOAD_RE = re.compile(
+    r"placeid:(?P<place>\d+),\s*userid:(?P<user>\d+),\s*"
+    r"universeid:(?P<universe>\d+)", re.I)
+_UDMUX_RE = re.compile(
+    r"UDMUX Address = (?P<address>[0-9a-fA-F:.]+), Port = (?P<port>\d+)"
+    r"(?: \| RCC Server Address = (?P<rcc>[0-9a-fA-F:.]+), Port = (?P<rccport>\d+))?")
+_BODY_FIELDS = {
+    "join_attempt": re.compile(r'"gameJoinAttemptId"\s*:\s*"([^"]+)"'),
+    "party": re.compile(r'"partyId"\s*:\s*"([^"]+)"'),
+    "origin": re.compile(r'"joinOrigin"\s*:\s*"([^"]+)"'),
+    "place": re.compile(r'"placeId"\s*:\s*(\d+)'),
+}
+_URL_RE = re.compile(r'url:\{\s*"([^"]+)"')
+_STATUS_RE = re.compile(r"\bstatus:(\d+)(?:\s+([^ ]+))?")
+_TIME_RE = re.compile(r"\btime:([\d.]+)ms")
+_BODY_SIZE_RE = re.compile(r"\bbodySize:(\d+)")
+_IP_RE = re.compile(r"\bip:([0-9a-fA-F:.]+)")
+_EXTERNAL_RE = re.compile(r"\bexternal:(\d+)")
+_RETRY_RE = re.compile(r"\bnumberOfTimesRetried:(\d+)")
+_ERROR_RE = re.compile(r"\berror:(\d+)\s+message:([^ ]+)")
+
+
+def _iter_lines(paths):
+    seen = set()
+    for path in map(str, paths):
+        real = os.path.realpath(path)
+        if real in seen:
+            continue
+        seen.add(real)
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as handle:
+                for line_number, line in enumerate(handle, 1):
+                    match = _LINE_RE.match(line.rstrip("\n"))
+                    if match:
+                        yield path, line_number, match.groupdict()
+        except OSError as ex:
+            logfunc(f"Roblox logs: could not read '{path}': {ex}")
+
+
+def _sort_time(value):
+    return value if isinstance(value, datetime) else datetime.min.replace(tzinfo=timezone.utc)
+
+
+@artifact_processor
+def robloxGameJoins(context):
+    data_headers = (
+        ("Joined", "datetime"), "Place ID", "Universe ID", "Game Instance ID",
+        "User ID", "Public Server", "Public Port", "RCC Server", "RCC Port",
+        "Join Attempt ID", "Party ID", "Join Origin", "Source File", "Line",
+    )
+    joins = []
+    source_paths = []
+    pending = {}
+    current_by_file = {}
+
+    for path, line_number, fields in _iter_lines(context.get_files_found()):
+        message = fields["message"]
+        if "joinGamePost" in message and " BODY:" in message:
+            pending[path] = {}
+            for key, pattern in _BODY_FIELDS.items():
+                match = pattern.search(message)
+                pending[path][key] = match.group(1) if match else ""
+
+        match = _JOIN_RE.search(message)
+        if match:
+            item = {
+                "time": iso_datetime(fields["timestamp"]),
+                "place": match.group("place"),
+                "universe": "",
+                "job": match.group("job"),
+                "user": "",
+                "public": "",
+                "public_port": "",
+                "rcc": match.group("rcc"),
+                "rcc_port": "",
+                "join_attempt": pending.get(path, {}).get("join_attempt", ""),
+                "party": pending.get(path, {}).get("party", ""),
+                "origin": pending.get(path, {}).get("origin", ""),
+                "path": path,
+                "line": line_number,
+            }
+            joins.append(item)
+            current_by_file[path] = item
+            if path not in source_paths:
+                source_paths.append(path)
+            continue
+
+        current = current_by_file.get(path)
+        if not current:
+            continue
+        match = _LOAD_RE.search(message)
+        if match:
+            current["place"] = match.group("place")
+            current["user"] = match.group("user")
+            current["universe"] = match.group("universe")
+        match = _UDMUX_RE.search(message)
+        if match:
+            current["public"] = match.group("address")
+            current["public_port"] = match.group("port")
+            current["rcc"] = match.group("rcc") or current["rcc"]
+            current["rcc_port"] = match.group("rccport") or ""
+
+    data_list = [(
+        item["time"], item["place"], item["universe"], item["job"], item["user"],
+        item["public"], item["public_port"], item["rcc"], item["rcc_port"],
+        item["join_attempt"], item["party"], item["origin"],
+        context.get_relative_path(item["path"]), item["line"],
+    ) for item in joins]
+    data_list.sort(key=lambda row: _sort_time(row[0]))
+    logfunc(f"Roblox Game Joins: {len(data_list)} join(s).")
+    return data_headers, data_list, "\n".join(source_paths)
+
+
+@artifact_processor
+def robloxHttpActivity(context):
+    data_headers = (
+        ("Response/Failure Logged", "datetime"), "Host", "URL", "HTTP Status", "Error",
+        "Server IP", "Elapsed (ms)", "Body Size (bytes)", "External",
+        "Retries", "Source File", "Line",
+    )
+    data_list = []
+    source_paths = []
+    for path, line_number, fields in _iter_lines(context.get_files_found()):
+        message = fields["message"]
+        url_match = _URL_RE.search(message)
+        if not url_match or "Http" not in fields["component"]:
+            continue
+        url = url_match.group(1)
+        status = _STATUS_RE.search(message)
+        timing = _TIME_RE.search(message)
+        body_size = _BODY_SIZE_RE.search(message)
+        ip_address = _IP_RE.search(message)
+        external = _EXTERNAL_RE.search(message)
+        retries = _RETRY_RE.search(message)
+        error = _ERROR_RE.search(message)
+        try:
+            host = urlsplit(url).hostname or ""
+        except ValueError:
+            host = ""
+        data_list.append((
+            iso_datetime(fields["timestamp"]), host, url,
+            status.group(1) if status else "",
+            f"{error.group(1)}: {error.group(2)}" if error else "",
+            ip_address.group(1) if ip_address else "",
+            timing.group(1) if timing else "",
+            body_size.group(1) if body_size else "",
+            "Yes" if external and external.group(1) == "1" else "No",
+            retries.group(1) if retries else "",
+            context.get_relative_path(path), line_number,
+        ))
+        if path not in source_paths:
+            source_paths.append(path)
+    data_list.sort(key=lambda row: _sort_time(row[0]))
+    logfunc(f"Roblox HTTP Activity: {len(data_list)} request record(s).")
+    return data_headers, data_list, "\n".join(source_paths)
+
+
+@artifact_processor
+def robloxPlayerLog(context):
+    data_headers = (
+        ("Timestamp", "datetime"), "Elapsed (s)", "Severity", "Component",
+        "Thread", "Level", "Message", "Source File", "Line",
+    )
+    data_list = []
+    source_paths = []
+    for path, line_number, fields in _iter_lines(context.get_files_found()):
+        data_list.append((
+            iso_datetime(fields["timestamp"]),
+            fields["elapsed"],
+            fields["severity"] or "",
+            fields["component"],
+            fields["thread"],
+            fields["level"],
+            fields["message"][:10000],
+            context.get_relative_path(path),
+            line_number,
+        ))
+        if path not in source_paths:
+            source_paths.append(path)
+    data_list.sort(key=lambda row: _sort_time(row[0]))
+    logfunc(f"Roblox Player Log: {len(data_list)} structured event(s).")
+    return data_headers, data_list, "\n".join(source_paths)

--- a/scripts/artifacts/robloxStorage.py
+++ b/scripts/artifacts/robloxStorage.py
@@ -1,0 +1,407 @@
+__artifacts_v2__ = {
+    "robloxWebKitLocalStorage": {
+        "name": "Roblox WebKit Local Storage",
+        "description": "Key/value records retained by Roblox Desktop's embedded "
+                       "WebKit origins, including real-time state, feature caches, "
+                       "locale data and identity-verification state.",
+        "author": "@AlexisBrignoni, Codex",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Roblox (macOS)",
+        "notes": "UTF-16 values are decoded and JSON is normalized. Values are "
+                 "reported in full and may contain usable credentials. JSON "
+                 "normalization can change whitespace without changing its data.",
+        "paths": (
+            "*/Library/WebKit/com.roblox.RobloxPlayer/WebsiteData/*/*/*/"
+            "LocalStorage/localstorage.sqlite3",
+            "*/Library/WebKit/com.roblox.RobloxPlayer/WebsiteData/*/*/*/origin",
+        ),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "database",
+        "sample_data": {
+            "roblox_macos": "Roblox 0.732.0.7321040 macOS | 20 rows",
+        },
+    },
+    "robloxIndexedDB": {
+        "name": "Roblox WebKit IndexedDB",
+        "description": "Database and object-store records from Roblox Desktop's "
+                       "WebKit IndexedDB stores. Serialized keys and values receive "
+                       "a heuristic readable-text preview and retain their raw size "
+                       "for follow-up analysis.",
+        "author": "@AlexisBrignoni, Codex",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Roblox (macOS)",
+        "notes": "WebKit uses a binary structured-clone encoding. This parser does "
+                 "not fully deserialize every JavaScript value type; it extracts "
+                 "embedded readable strings and limits each preview to 5,000 "
+                 "characters. Preview output may contain usable credentials.",
+        "paths": (
+            "*/Library/WebKit/com.roblox.RobloxPlayer/WebsiteData/*/*/*/"
+            "IndexedDB/*/IndexedDB.sqlite3",
+            "*/Library/WebKit/com.roblox.RobloxPlayer/WebsiteData/*/*/*/origin",
+        ),
+        "output_types": ["html", "tsv", "lava"],
+        "artifact_icon": "database",
+        "sample_data": {
+            "roblox_macos": "Roblox 0.732.0.7321040 macOS | 2 rows",
+        },
+    },
+    "robloxAssetCache": {
+        "name": "Roblox Asset Cache Index",
+        "description": "Roblox's rbx-storage cache index, recording cached object "
+                       "identifiers, last-access times, logical sizes, hit counts, "
+                       "categories, raw score values, expiry values and stored-content "
+                       "signatures.",
+        "author": "@AlexisBrignoni, Codex",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Roblox (macOS)",
+        "notes": "The 16-byte IDs are opaque cache keys. Atime behaves as Unix "
+                 "milliseconds and ttl, when present, behaves as Unix seconds in the "
+                 "tested corpus. Score appears to be a ranking or eviction metric; "
+                 "its exact semantics are unverified, so it is reported raw.",
+        "paths": ("*/Library/Roblox/rbx-storage.db",),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "archive",
+        "sample_data": {
+            "roblox_macos": "Roblox 0.732.0.7321040 macOS | 2479 rows",
+        },
+    },
+    "robloxWebKitNetworkCache": {
+        "name": "Roblox WebKit Network Cache",
+        "description": "HTTP resources identified in Roblox Desktop's WebKit network "
+                       "cache, including URL, host, heuristically recovered HTTP "
+                       "metadata, record size and any companion blob size.",
+        "author": "@AlexisBrignoni, Codex",
+        "creation_date": "2026-07-28",
+        "last_update_date": "2026-07-28",
+        "requirements": "none",
+        "category": "Roblox (macOS)",
+        "notes": "WebKit's cache is an internal, versioned implementation format. "
+                 "URLs and query parameters are reported in full. HTTP Date, content "
+                 "type and ETag are heuristic string recoveries and can be absent or "
+                 "imperfect. A companion -blob size is exact when present; otherwise "
+                 "the response body may be inline or absent and is not decoded here.",
+        "paths": (
+            "*/Library/Caches/com.roblox.RobloxPlayer/WebKit/NetworkCache/"
+            "Version */Records/*/Resource/*",
+        ),
+        "output_types": ["html", "tsv", "timeline", "lava"],
+        "artifact_icon": "globe",
+        "sample_data": {
+            "roblox_macos": "Roblox 0.732.0.7321040 macOS | 408 rows",
+        },
+    },
+}
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from urllib.parse import urlsplit
+
+from scripts.ilapfuncs import artifact_processor, logfunc, open_sqlite_db_readonly
+from scripts.roblox import (
+    compact_value,
+    decode_webkit_value,
+    epoch_datetime,
+    origin_from_webkit_file,
+)
+
+_COMMON_MIME_TYPES = {
+    "application/gzip",
+    "application/javascript",
+    "application/json",
+    "application/manifest+json",
+    "application/octet-stream",
+    "application/wasm",
+    "application/x-javascript",
+    "application/xml",
+    "audio/mpeg",
+    "audio/ogg",
+    "font/otf",
+    "font/ttf",
+    "font/woff",
+    "font/woff2",
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/svg+xml",
+    "image/webp",
+    "text/css",
+    "text/html",
+    "text/javascript",
+    "text/plain",
+    "text/xml",
+    "video/mp4",
+    "video/webm",
+}
+
+
+def _source_origin(database_path):
+    folder = os.path.dirname(database_path)
+    for _ in range(5):
+        origin_path = os.path.join(folder, "origin")
+        if os.path.isfile(origin_path):
+            return origin_from_webkit_file(origin_path)
+        folder = os.path.dirname(folder)
+    return ""
+
+
+@artifact_processor
+def robloxWebKitLocalStorage(context):
+    data_headers = ("Origin", "Key", "Value", "Value Length", "Source File")
+    data_list = []
+    source_paths = []
+    for file_found in map(str, context.get_files_found()):
+        if os.path.basename(file_found) != "localstorage.sqlite3":
+            continue
+        connection = open_sqlite_db_readonly(file_found)
+        if not connection:
+            continue
+        try:
+            rows = connection.execute(
+                "SELECT key, value FROM ItemTable ORDER BY key").fetchall()
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            logfunc(f"Roblox Local Storage: could not read '{file_found}': {ex}")
+            connection.close()
+            continue
+        connection.close()
+        if rows:
+            source_paths.append(file_found)
+        origin = _source_origin(file_found)
+        for key, raw_value in rows:
+            decoded = decode_webkit_value(raw_value)
+            try:
+                value = compact_value(json.loads(decoded))
+            except (TypeError, ValueError):
+                value = compact_value(decoded)
+            data_list.append((
+                origin, key, value, len(decoded),
+                context.get_relative_path(file_found),
+            ))
+    logfunc(f"Roblox WebKit Local Storage: {len(data_list)} record(s).")
+    return data_headers, data_list, "\n".join(source_paths)
+
+
+def _readable_strings(value):
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        if "\x00" not in value:
+            return value[:5000]
+        data = value.encode("latin-1", "replace")
+    else:
+        data = bytes(value)
+    recovered = []
+    for match in re.finditer(rb"(?:[\x20-\x7e]\x00){3,}", data):
+        text = match.group().decode("utf-16-le", "ignore").strip()
+        if text and text not in recovered:
+            recovered.append(text)
+    for match in re.finditer(rb"[\x20-\x7e]{4,}", data):
+        text = match.group().decode("utf-8", "ignore").strip()
+        if text and text not in recovered:
+            recovered.append(text)
+    return " | ".join(recovered)[:5000]
+
+
+@artifact_processor
+def robloxIndexedDB(context):
+    data_headers = (
+        "Origin", "Database", "Object Store", "Record ID", "Key Preview",
+        "Value Preview", "Value Size (bytes)", "Source File",
+    )
+    data_list = []
+    source_paths = []
+    for file_found in map(str, context.get_files_found()):
+        if os.path.basename(file_found) != "IndexedDB.sqlite3":
+            continue
+        connection = open_sqlite_db_readonly(file_found)
+        if not connection:
+            continue
+        try:
+            info = dict(connection.execute(
+                "SELECT key, value FROM IDBDatabaseInfo").fetchall())
+            stores = dict(connection.execute(
+                "SELECT id, name FROM ObjectStoreInfo").fetchall())
+            rows = connection.execute(
+                "SELECT objectStoreID, recordID, key, value FROM Records "
+                "ORDER BY recordID").fetchall()
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            logfunc(f"Roblox IndexedDB: could not read '{file_found}': {ex}")
+            connection.close()
+            continue
+        connection.close()
+        if rows:
+            source_paths.append(file_found)
+        origin = _source_origin(file_found)
+        for store_id, record_id, key, value in rows:
+            key_preview = _readable_strings(key)
+            value_preview = _readable_strings(value) or bytes(value).hex()[:5000]
+            data_list.append((
+                origin,
+                info.get("DatabaseName", ""),
+                stores.get(store_id, str(store_id)),
+                record_id,
+                key_preview,
+                value_preview,
+                len(value) if value is not None else 0,
+                context.get_relative_path(file_found),
+            ))
+    logfunc(f"Roblox WebKit IndexedDB: {len(data_list)} record(s).")
+    return data_headers, data_list, "\n".join(source_paths)
+
+
+def _content_signature(content):
+    if not content:
+        return ""
+    signatures = (
+        (b"RBXH", "RBXH"),
+        (b"\x89PNG\r\n\x1a\n", "PNG"),
+        (b"\xff\xd8\xff", "JPEG"),
+        (b"OggS", "Ogg"),
+        (b"RIFF", "RIFF"),
+        (b"PK\x03\x04", "ZIP"),
+        (b"\x1f\x8b", "gzip"),
+    )
+    for marker, label in signatures:
+        if bytes(content).startswith(marker):
+            return label
+    return bytes(content[:8]).hex().upper()
+
+
+@artifact_processor
+def robloxAssetCache(context):
+    data_headers = (
+        ("Last Access", "datetime"), ("Expires", "datetime"), "Cache ID",
+        "Category", "Logical Size (bytes)", "Hit Count", "Score",
+        "Stored Content Size (bytes)", "Content Signature", "Source File",
+    )
+    data_list = []
+    source_paths = []
+    for file_found in map(str, context.get_files_found()):
+        connection = open_sqlite_db_readonly(file_found)
+        if not connection:
+            continue
+        try:
+            rows = connection.execute(
+                "SELECT hex(id), category, size, hits, atime, score, ttl, "
+                "content FROM files ORDER BY atime").fetchall()
+        except Exception as ex:  # pylint: disable=broad-exception-caught
+            logfunc(f"Roblox asset cache: could not read '{file_found}': {ex}")
+            connection.close()
+            continue
+        connection.close()
+        if rows:
+            source_paths.append(file_found)
+        for cache_id, category, size, hits, atime, score, ttl, content in rows:
+            data_list.append((
+                epoch_datetime(atime),
+                epoch_datetime(ttl),
+                cache_id,
+                category,
+                size,
+                hits,
+                score,
+                len(content) if content else 0,
+                _content_signature(content),
+                context.get_relative_path(file_found),
+            ))
+    logfunc(f"Roblox Asset Cache Index: {len(data_list)} record(s).")
+    return data_headers, data_list, "\n".join(source_paths)
+
+
+def _cache_metadata(path):
+    try:
+        with open(path, "rb") as handle:
+            data = handle.read()
+    except OSError:
+        return None
+
+    strings = []
+    for match in re.finditer(rb"(?:[\x20-\x7e]\x00){8,}", data):
+        strings.append(match.group().decode("utf-16-le", "ignore"))
+    for match in re.finditer(rb"[\x20-\x7e]{4,}", data):
+        strings.append(match.group().decode("utf-8", "ignore"))
+
+    url = next((item for item in strings if item.startswith(("http://", "https://"))), "")
+    if not url:
+        return None
+    date_value = next((item for item in strings
+                       if re.match(r"^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), ", item)), "")
+    cached = ""
+    if date_value:
+        try:
+            cached = parsedate_to_datetime(date_value)
+            if isinstance(cached, datetime) and cached.tzinfo is None:
+                cached = datetime(
+                    cached.year, cached.month, cached.day, cached.hour,
+                    cached.minute, cached.second, cached.microsecond,
+                    tzinfo=timezone.utc)
+        except (TypeError, ValueError):
+            cached = ""
+    mime = ""
+    for item in strings:
+        candidate = item.lower()
+        base_type = candidate.split(";", 1)[0]
+        if (item == candidate and base_type in _COMMON_MIME_TYPES
+                and re.fullmatch(
+                    r"[a-z]+/[a-z0-9][a-z0-9.+_-]*"
+                    r"(?:;\s*charset=[a-z0-9._-]+)?", candidate)):
+            mime = item
+            break
+    etag = ""
+    for index, item in enumerate(strings[:-1]):
+        if item.lower() == "etag":
+            etag = strings[index + 1]
+            break
+    return cached, url, mime, etag
+
+
+@artifact_processor
+def robloxWebKitNetworkCache(context):
+    data_headers = (
+        ("Recovered HTTP Date", "datetime"), "Host", "URL",
+        "Recovered Content Type (heuristic)", "Recovered ETag (heuristic)",
+        "Cache Record Size (bytes)", "Companion Blob Size (bytes)",
+        "Body Storage", "Source Cache File",
+    )
+    data_list = []
+    source_paths = []
+    for file_found in map(str, context.get_files_found()):
+        if file_found.endswith("-blob"):
+            continue
+        metadata = _cache_metadata(file_found)
+        if not metadata:
+            continue
+        cached, url, mime, etag = metadata
+        try:
+            host = urlsplit(url).hostname or ""
+        except ValueError:
+            host = ""
+        blob_path = file_found + "-blob"
+        if os.path.isfile(blob_path):
+            body_size = os.path.getsize(blob_path)
+            body_storage = "Companion -blob file"
+        else:
+            body_size = ""
+            body_storage = "Inline or absent (not decoded)"
+        try:
+            metadata_size = os.path.getsize(file_found)
+        except OSError:
+            metadata_size = 0
+        data_list.append((
+            cached, host, url, mime, etag, metadata_size, body_size,
+            body_storage, context.get_relative_path(file_found),
+        ))
+        source_paths.append(file_found)
+    data_list.sort(
+        key=lambda row: row[0] if isinstance(row[0], datetime)
+        else datetime.min.replace(tzinfo=timezone.utc))
+    logfunc(f"Roblox WebKit Network Cache: {len(data_list)} response(s).")
+    return data_headers, data_list, "\n".join(source_paths[:50])

--- a/scripts/roblox.py
+++ b/scripts/roblox.py
@@ -1,0 +1,86 @@
+"""Shared helpers for Roblox Desktop artifacts.
+
+Author: @AlexisBrignoni, Codex
+"""
+
+import json
+import re
+from datetime import datetime, timezone
+
+
+def read_json(path):
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            return json.load(handle)
+    except (OSError, ValueError, TypeError):
+        return None
+
+
+def epoch_datetime(value):
+    """Convert Unix seconds or milliseconds to an aware UTC datetime."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return ""
+    if number <= 0:
+        return ""
+    if number > 100_000_000_000:
+        number /= 1000
+    try:
+        return datetime.fromtimestamp(number, tz=timezone.utc)
+    except (OSError, OverflowError, ValueError):
+        return ""
+
+
+def iso_datetime(value):
+    """Parse the ISO-8601 timestamps written at the start of Roblox log lines."""
+    if not value:
+        return ""
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return ""
+
+
+def decode_webkit_value(value):
+    """Decode WebKit Local Storage's UTF-16 blob representation."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    body = bytes(value)
+    if not body:
+        return ""
+    for encoding in ("utf-16-le", "utf-8"):
+        try:
+            return body.decode(encoding).rstrip("\x00")
+        except UnicodeDecodeError:
+            continue
+    return body.hex()
+
+
+def compact_value(value, limit=None):
+    """Render a scalar or compact JSON value, optionally applying a preview limit."""
+    if isinstance(value, (dict, list)):
+        value = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    elif value is None:
+        value = ""
+    else:
+        value = str(value)
+    if limit is not None and len(value) > limit:
+        return value[:limit] + "…"
+    return value
+
+
+def origin_from_webkit_file(path):
+    """Recover the origin strings from WebKit's small binary origin file."""
+    try:
+        with open(path, "rb") as handle:
+            data = handle.read(4096)
+    except OSError:
+        return ""
+    strings = re.findall(rb"[\x20-\x7e]{4,}", data)
+    decoded = [item.decode("ascii", "ignore").strip("\x00") for item in strings]
+    scheme = next((item for item in decoded if item in ("http", "https")), "")
+    host = next((item for item in decoded if "." in item and "/" not in item), "")
+    return f"{scheme}://{host}" if scheme and host else host


### PR DESCRIPTION
## Summary
- add 13 Roblox Desktop artifacts for macOS account, activity, logs, cookies, WebKit storage, IndexedDB, asset cache, and network cache data
- preserve raw credential-bearing values for evidentiary analysis
- document heuristic and format limitations in artifact notes

## Validation
- focused Roblox profile against a real path-preserving ZIP corpus: 13 artifacts, 5,355 records, no parser errors
- CI-equivalent pylint: 10.00/10
- 26 local focused tests passed (test file intentionally not included because it is not required for artifact runtime)
- HTML, TSV, timeline, and LAVA output verified