### PR TITLE
Correct Roblox artifact metadata

### DIFF
--- a/scripts/artifacts/robloxAccount.py
+++ b/scripts/artifacts/robloxAccount.py
@@ -7,12 +7,14 @@ __artifacts_v2__ = {
                        "theme, subscription state and installed client version.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (macOS)",
         "notes": "Values are reported verbatim for evidentiary analysis, including "
-                 "PlayerHydrationBlob and PlayerHydrationSignature. Output must be "
-                 "handled as credential-bearing evidence. Timestamps are UTC.",
+                 "PlayerHydrationBlob and PlayerHydrationSignature. These values can "
+                 "contain sensitive account state, but the parser does not classify "
+                 "the signature as a reusable authentication credential. Timestamps "
+                 "are UTC.",
         "paths": (
             "*/Library/Roblox/LocalStorage/appStorage.json",
             "*/Library/Preferences/com.roblox.RobloxPlayer.plist",
@@ -22,7 +24,6 @@ __artifacts_v2__ = {
         "artifact_icon": "user",
         "sample_data": {
             "roblox_macos": "Roblox 0.732.0.7321040 macOS | 28 rows",
-            "roblox_windows": "Roblox 0.732.23.7321040 Windows | 22 rows",
         },
     },
     "robloxSettings": {
@@ -32,7 +33,7 @@ __artifacts_v2__ = {
                        "audio, input and window settings.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (macOS)",
         "notes": "Compound XML values such as vectors are flattened into a compact "
@@ -44,7 +45,6 @@ __artifacts_v2__ = {
         "artifact_icon": "settings",
         "sample_data": {
             "roblox_macos": "Roblox 0.732.0.7321040 macOS | 74 rows",
-            "roblox_windows": "Roblox 0.732.23.7321040 Windows | 74 rows",
         },
     },
 }

--- a/scripts/artifacts/robloxActivity.py
+++ b/scripts/artifacts/robloxActivity.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "version, session IDs and result state.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (macOS)",
         "notes": "memProfStorage is rolling state and generally describes the most "
@@ -19,17 +19,16 @@ __artifacts_v2__ = {
         "artifact_icon": "clock",
         "sample_data": {
             "roblox_macos": "Roblox 0.732.0.7321040 macOS | 1 row",
-            "roblox_windows": "Roblox 0.732.23.7321040 Windows | 1 row",
         },
     },
     "robloxPresence": {
         "name": "Roblox Presence",
-        "description": "Retained Roblox user-presence state from WebKit or WebView2 "
+        "description": "Retained Roblox user-presence state from embedded-browser "
                        "Local Storage, identifying users, their presence type and "
                        "last reported location.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (macOS)",
         "notes": "Presence type values are preserved numerically because Roblox may "
@@ -42,22 +41,21 @@ __artifacts_v2__ = {
         "artifact_icon": "users",
         "sample_data": {
             "roblox_macos": "Roblox 0.732.0.7321040 macOS | 2 rows",
-            "roblox_windows": "Roblox 0.732.23.7321040 Windows | 5 rows",
         },
     },
     "robloxNotifications": {
         "name": "Roblox Real-Time Notifications",
-        "description": "Real-time notifications retained in Roblox WebKit or "
-                       "WebView2 Local Storage. Chat notifications can preserve the "
-                       "sender, conversation ID and message text shown to the user.",
+        "description": "Real-time notifications retained in Roblox embedded-browser "
+                       "Local Storage. Chat notifications can preserve the sender, "
+                       "conversation ID and message text shown to the user.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (macOS)",
-        "notes": "The live key is overwritten as notifications arrive. WebView2 "
-                 "LevelDB can retain superseded versions, but this remains a partial "
-                 "notification history.",
+        "notes": "Only live Local Storage versions are parsed. The key can be "
+                 "overwritten as notifications arrive, so output is a partial "
+                 "notification history rather than a complete message record.",
         "paths": (
             "*/Library/WebKit/com.roblox.RobloxPlayer/WebsiteData/*/*/*/"
             "LocalStorage/localstorage.sqlite3",
@@ -66,7 +64,6 @@ __artifacts_v2__ = {
         "artifact_icon": "bell",
         "sample_data": {
             "roblox_macos": "Roblox 0.732.0.7321040 macOS | 1 row",
-            "roblox_windows": "Roblox 0.732.23.7321040 Windows | 1 row",
         },
     },
 }

--- a/scripts/artifacts/robloxCookies.py
+++ b/scripts/artifacts/robloxCookies.py
@@ -6,12 +6,13 @@ __artifacts_v2__ = {
                        "time, flags and the complete stored value.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (macOS)",
         "notes": "All values are reported verbatim for evidentiary analysis. The "
-                 "output can contain live authentication, anti-bot, "
-                 "identity-verification and session credentials.",
+                 "output can contain authentication, anti-bot, identity-verification "
+                 "and session values; the parser does not test whether they remain "
+                 "valid or reusable.",
         "paths": (
             "*/Library/HTTPStorages/com.roblox.RobloxPlayer.binarycookies",
         ),

--- a/scripts/artifacts/robloxLogs.py
+++ b/scripts/artifacts/robloxLogs.py
@@ -7,7 +7,7 @@ __artifacts_v2__ = {
                        "RCC server addresses recorded by the client.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (macOS)",
         "notes": "UDMUX and RCC labels follow the source log. In the tested corpus "
@@ -21,7 +21,6 @@ __artifacts_v2__ = {
         "artifact_icon": "log-in",
         "sample_data": {
             "roblox_macos": "Roblox 0.732.0.7321040 macOS | 3 rows",
-            "roblox_windows": "Roblox 0.732.23.7321040 Windows | 2 rows",
         },
     },
     "robloxHttpActivity": {
@@ -31,12 +30,14 @@ __artifacts_v2__ = {
                        "server IP, elapsed time, body size and retry state.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (macOS)",
         "notes": "URLs and query parameters are reported verbatim for evidentiary "
-                 "analysis and may contain usable credentials. Player-log URLs form "
-                 "a partial activity record, not browser history.",
+                 "analysis and may contain tokens or credential-like values. The "
+                 "parser does not determine whether those values remain valid or "
+                 "reusable. Player-log URLs form a partial activity record, not "
+                 "browser history.",
         "paths": (
             "*/Library/Logs/Roblox/*_Player_*.log",
         ),
@@ -44,7 +45,6 @@ __artifacts_v2__ = {
         "artifact_icon": "globe",
         "sample_data": {
             "roblox_macos": "Roblox 0.732.0.7321040 macOS | 71 rows",
-            "roblox_windows": "Roblox 0.732.23.7321040 Windows | 119 rows",
         },
     },
     "robloxPlayerLog": {
@@ -54,7 +54,7 @@ __artifacts_v2__ = {
                        "component and message.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (macOS)",
         "notes": "Long messages are limited to 10,000 characters. The first "
@@ -66,7 +66,6 @@ __artifacts_v2__ = {
         "artifact_icon": "file-text",
         "sample_data": {
             "roblox_macos": "Roblox 0.732.0.7321040 macOS | 2249 rows",
-            "roblox_windows": "Roblox 0.732.23.7321040 Windows | 3644 rows",
         },
     },
 }

--- a/scripts/artifacts/robloxStorage.py
+++ b/scripts/artifacts/robloxStorage.py
@@ -6,12 +6,14 @@ __artifacts_v2__ = {
                        "locale data and identity-verification state.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (macOS)",
         "notes": "UTF-16 values are decoded and JSON is normalized. Values are "
-                 "reported in full and may contain usable credentials. JSON "
-                 "normalization can change whitespace without changing its data.",
+                 "reported in full and may contain tokens or credential-like data; "
+                 "the parser does not determine whether they remain valid or "
+                 "reusable. JSON normalization can change whitespace without "
+                 "changing its data.",
         "paths": (
             "*/Library/WebKit/com.roblox.RobloxPlayer/WebsiteData/*/*/*/"
             "LocalStorage/localstorage.sqlite3",
@@ -31,13 +33,14 @@ __artifacts_v2__ = {
                        "for follow-up analysis.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (macOS)",
         "notes": "WebKit uses a binary structured-clone encoding. This parser does "
                  "not fully deserialize every JavaScript value type; it extracts "
                  "embedded readable strings and limits each preview to 5,000 "
-                 "characters. Preview output may contain usable credentials.",
+                 "characters. Preview output may contain tokens or credential-like "
+                 "data whose validity and reusability are not assessed.",
         "paths": (
             "*/Library/WebKit/com.roblox.RobloxPlayer/WebsiteData/*/*/*/"
             "IndexedDB/*/IndexedDB.sqlite3",
@@ -57,7 +60,7 @@ __artifacts_v2__ = {
                        "signatures.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (macOS)",
         "notes": "The 16-byte IDs are opaque cache keys. Atime behaves as Unix "
@@ -78,7 +81,7 @@ __artifacts_v2__ = {
                        "metadata, record size and any companion blob size.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (macOS)",
         "notes": "WebKit's cache is an internal, versioned implementation format. "

--- a/scripts/artifacts/robloxWebView2.py
+++ b/scripts/artifacts/robloxWebView2.py
@@ -6,7 +6,7 @@ __artifacts_v2__ = {
                        "and complete DPAPI-protected blob.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (Windows)",
         "notes": "CookiesData is encrypted with Windows DPAPI and cannot be decrypted "
@@ -25,7 +25,7 @@ __artifacts_v2__ = {
                        "Windows WebView2 profile.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (Windows)",
         "notes": "Chromium v10 cookie values depend on the WebView2 Local State "
@@ -48,12 +48,13 @@ __artifacts_v2__ = {
                        "and referring visit identifiers.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (Windows)",
         "notes": "URLs and query parameters are reported in full and may contain "
-                 "challenge tokens or other credentials. History is a retained "
-                 "partial record and can include repeated visits.",
+                 "challenge tokens or credential-like values. The parser does not "
+                 "determine whether those values remain valid or reusable. History "
+                 "is a retained partial record and can include repeated visits.",
         "paths": (
             "*/AppData/Local/Roblox/UniversalApp/WebView2/EBWebView/Default/History",
         ),
@@ -69,12 +70,13 @@ __artifacts_v2__ = {
                        "recovered from Roblox's Windows WebView2 LevelDB.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (Windows)",
         "notes": "LevelDB table and log files preserve historical versions. Values "
-                 "are reported in full; JSON is compacted and may contain usable "
-                 "credentials, notifications and account state.",
+                 "are reported in full; JSON is compacted and may contain tokens, "
+                 "notifications and account state. The parser does not determine "
+                 "whether token-like values remain valid or reusable.",
         "paths": (
             "*/AppData/Local/Roblox/UniversalApp/WebView2/EBWebView/Default/"
             "Local Storage/leveldb/*",
@@ -92,7 +94,7 @@ __artifacts_v2__ = {
                        "origin, map, key and sequence attribution.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (Windows)",
         "notes": "Chromium Session Storage namespaces map origins to numbered maps. "
@@ -117,12 +119,14 @@ __artifacts_v2__ = {
                        "Roblox's Windows WebView2 IndexedDB LevelDB.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (Windows)",
         "notes": "The vendored Chromium IndexedDB reader returns decoded JavaScript "
                  "values where supported and explicit placeholders otherwise. "
-                 "Historical versions can repeat. Output may contain credentials.",
+                 "Historical versions can repeat. Output may contain tokens or "
+                 "credential-like values whose validity and reusability are not "
+                 "assessed.",
         "paths": (
             "*/AppData/Local/Roblox/UniversalApp/WebView2/EBWebView/Default/"
             "IndexedDB/https_www.roblox.com_0.indexeddb.leveldb/*",
@@ -141,13 +145,14 @@ __artifacts_v2__ = {
                        "storage details.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (Windows)",
         "notes": "Parses Chromium v3 index, data_N blocks and f_XXXXXX streams using "
                  "the published blockfile format. URLs and headers are reported in "
-                 "full. The cache is partial and can contain credential-bearing "
-                 "query parameters.",
+                 "full. The cache is partial and can contain tokens or "
+                 "credential-like query values; their validity and reusability are "
+                 "not assessed.",
         "paths": (
             "*/AppData/Local/Roblox/UniversalApp/WebView2/EBWebView/Default/"
             "Cache/Cache_Data/*",
@@ -165,7 +170,7 @@ __artifacts_v2__ = {
                        "from cached Roblox API responses.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (Windows)",
         "notes": "Only user-specific API endpoints are included; general feature "
@@ -190,7 +195,7 @@ __artifacts_v2__ = {
                        "cached Roblox API responses.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (Windows)",
         "notes": "One row is emitted per relationship, membership or search action. "
@@ -215,7 +220,7 @@ __artifacts_v2__ = {
                        "Storage.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (Windows)",
         "notes": "Purchase-flow telemetry documents page views, available products "
@@ -242,13 +247,16 @@ __artifacts_v2__ = {
                        "Roblox API responses.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (Windows)",
         "notes": "Only records containing an actual user-linked item or wall post "
                  "are emitted. Empty lists, endpoint errors, category catalogs, "
                  "feature metadata and settings-option catalogs are excluded. "
-                 "Identical retained response versions are deduplicated.",
+                 "Identical retained response versions are deduplicated. The tested "
+                 "Windows corpus produced zero rows, so the supported endpoint "
+                 "schemas are parser capabilities rather than observed sample "
+                 "evidence.",
         "paths": (
             "*/AppData/Local/Roblox/UniversalApp/WebView2/EBWebView/Default/"
             "Cache/Cache_Data/*",
@@ -264,7 +272,7 @@ __artifacts_v2__ = {
                        "HTML body, created and updated times, and read/system state.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-28",
-        "last_update_date": "2026-07-28",
+        "last_update_date": "2026-07-29",
         "requirements": "none",
         "category": "Roblox (Windows)",
         "notes": "Recovered from retained privatemessages.roblox.com response bodies. "

--- a/scripts/artifacts/robloxWindows.py
+++ b/scripts/artifacts/robloxWindows.py
@@ -17,17 +17,14 @@ from scripts.artifacts.robloxLogs import (
 from scripts.ilapfuncs import artifact_processor
 
 
-def _windows_artifact(parser, paths):
+def _windows_artifact(parser, paths, sample_description):
     original = parser.__wrapped__
     source = original.__globals__["__artifacts_v2__"][original.__name__]
     metadata = dict(source)
     metadata["name"] = source["name"].replace("Roblox ", "Roblox Windows ", 1)
     metadata["category"] = "Roblox (Windows)"
     metadata["paths"] = paths
-    metadata["sample_data"] = {
-        key: value for key, value in source.get("sample_data", {}).items()
-        if "windows" in key.lower()
-    }
+    metadata["sample_data"] = {"roblox_windows": sample_description}
     return metadata
 
 
@@ -38,14 +35,17 @@ __artifacts_v2__ = {
     "robloxWindowsPresence": _windows_artifact(
         _roblox_presence,
         (_WEBVIEW2 + "Local Storage/leveldb/*",),
+        "Roblox 0.732.23.7321040 Windows | 5 rows",
     ),
     "robloxWindowsNotifications": _windows_artifact(
         _roblox_notifications,
         (_WEBVIEW2 + "Local Storage/leveldb/*",),
+        "Roblox 0.732.23.7321040 Windows | 1 row",
     ),
     "robloxWindowsGameJoins": _windows_artifact(
         _roblox_game_joins,
         (_LOCAL_ROBLOX + "logs/*_Player_*.log",),
+        "Roblox 0.732.23.7321040 Windows | 2 rows",
     ),
     "robloxWindowsAccount": _windows_artifact(
         _roblox_account,
@@ -53,6 +53,7 @@ __artifacts_v2__ = {
             _LOCAL_ROBLOX + "LocalStorage/appStorage.json",
             _LOCAL_ROBLOX + "AnalysticsSettings.xml",
         ),
+        "Roblox 0.732.23.7321040 Windows | 22 rows",
     ),
 }
 


### PR DESCRIPTION
## Summary
- make Roblox sample-data declarations match each artifact platform and path set
- give Windows wrappers explicit Windows sample metadata
- correct notification-history and credential-validity wording
- document the lack of a positive User Content sample
- update audited artifact metadata dates

## Validation
- full macOS and Windows corpus runs completed without parser errors
- all 28 declared sample row counts matched generated TSV output
- platform/category/path metadata audit passed across all 29 Roblox artifacts
- 13 targeted tests passed
- changed-file pylint and diff checks passed

## Scope
Runtime artifact modules only. Local profiles, tests, generated reports, and corpus data are excluded.