### PR TITLE
Register Telegram corpus sample data

### DIFF
--- a/scripts/artifacts/telegramAccounts.py
+++ b/scripts/artifacts/telegramAccounts.py
@@ -23,6 +23,9 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "user",
+        "sample_data": {
+            "telegram_macos": "Telegram Desktop 7.0.6 macOS | 1 row",
+        },
     },
 }
 

--- a/scripts/artifacts/telegramActivity.py
+++ b/scripts/artifacts/telegramActivity.py
@@ -23,6 +23,9 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "lava"],
         "artifact_icon": "users",
+        "sample_data": {
+            "telegram_macos": "Telegram Desktop 7.0.6 macOS | 2 rows",
+        },
     },
     "telegramLocalFiles": {
         "name": "Telegram Desktop Local Files",
@@ -49,6 +52,9 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "file",
+        "sample_data": {
+            "telegram_macos": "Telegram Desktop 7.0.6 macOS | 2 rows",
+        },
     },
 }
 

--- a/scripts/artifacts/telegramCache.py
+++ b/scripts/artifacts/telegramCache.py
@@ -28,6 +28,9 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "image",
+        "sample_data": {
+            "telegram_macos": "Telegram Desktop 7.0.6 macOS | 239 rows",
+        },
     },
 }
 

--- a/scripts/artifacts/telegramLogs.py
+++ b/scripts/artifacts/telegramLogs.py
@@ -20,6 +20,9 @@ __artifacts_v2__ = {
         ),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "file-lines",
+        "sample_data": {
+            "telegram_macos": "Telegram Desktop 7.0.6 macOS | 12 rows",
+        },
     },
 }
 


### PR DESCRIPTION
Adds the private corpus sample key and verified row counts to the five Telegram Desktop artifact metadata blocks. The raw acquisition remains only on the private data drive and is not part of this PR. Local corpus validation reproduced all declared counts: Accounts 1, Recent Peers 2, Local Files 2, Application Log 12, Recovered Cache 239.