### PR TITLE
fix: report Notification BootId as stored; remove unsourced doc claims

### DIFF
--- a/admin/test/scripts/test_windows_system.py
+++ b/admin/test/scripts/test_windows_system.py
@@ -101,6 +101,8 @@ def test_notifications_include_handler_and_payload_hash(tmp_path):
         _Context([database_path])
     )
     assert len(rows) == 1
+    # BootId is reported as stored, never decoded as a FILETIME timestamp
+    assert rows[0][4] == 116444736000000000
     assert rows[0][7] == "test.handler"
     assert rows[0][11] == "DLEAPP-NOTIFICATION-TEST-001"
     assert len(rows[0][16]) == 64

--- a/scripts/artifacts/windowsApps.py
+++ b/scripts/artifacts/windowsApps.py
@@ -41,7 +41,8 @@ __artifacts_v2__ = {
                  "database is LocalState/shared.sqlite. Numeric timestamps "
                  "are converted from Windows FILETIME; their original "
                  "application-level timezone semantics may vary. Alternate "
-                 "Date Taken is an app-maintained fallback and must not be "
+                 "Date Taken is a separate app-recorded date whose "
+                 "derivation is not documented; it must not be "
                  "treated as proof of capture time. Zero coordinates are "
                  "retained as stored and do not by themselves prove a "
                  "location. A blank preview accompanied by 'Original file "
@@ -93,14 +94,17 @@ __artifacts_v2__ = {
                        "including scheduled, created, and updated times.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-29",
-        "last_update_date": "2026-07-29",
+        "last_update_date": "2026-07-30",
         "requirements": "python-registry",
         "category": "Windows Apps",
         "notes": "Modernized from WLEAPP and validated with Clock "
                  "11.2605.10.0. Scheduled fields are device-local; created "
                  "and updated values are converted from Windows FILETIME. "
-                 "The registry parser reads offline hives without loading "
-                 "them into the examiner system registry.",
+                 "Days of Week is reported as stored, undecoded. When the "
+                 "source carries no IsRecurring value, Recurring is derived "
+                 "from a nonzero Days of Week value. The registry parser "
+                 "reads offline hives without loading them into the "
+                 "examiner system registry.",
         "paths": (
             "*/AppData/Local/Packages/Microsoft.WindowsAlarms_*/"
             "LocalState/Alarms/Alarms.json",
@@ -471,7 +475,7 @@ def windowsAlarms(context):
         "Alarm Time (device local)",
         "Enabled",
         "Recurring",
-        "Days of Week (bitmask)",
+        "Days of Week (database value)",
         "Snooze Interval (minutes)",
         "Chime Name / Resource",
         "Chime Path",

--- a/scripts/artifacts/windowsSystem.py
+++ b/scripts/artifacts/windowsSystem.py
@@ -51,11 +51,12 @@ __artifacts_v2__ = {
                        "text, and the preserved payload.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-29",
-        "last_update_date": "2026-07-29",
+        "last_update_date": "2026-07-30",
         "requirements": "beautifulsoup4",
         "category": "Windows System",
-        "notes": "Modernized from WLEAPP. Arrival, expiry, and boot values use "
-                 "the Windows FILETIME epoch and are reported in UTC.",
+        "notes": "Modernized from WLEAPP. Arrival and expiry values use the "
+                 "Windows FILETIME epoch and are reported in UTC. Boot ID is "
+                 "reported as stored because its encoding is not documented.",
         "paths": (
             "*/AppData/Local/Microsoft/Windows/Notifications/wpndatabase.db*",
         ),
@@ -96,13 +97,14 @@ __artifacts_v2__ = {
                        "present, and recorded exit status.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-29",
-        "last_update_date": "2026-07-29",
+        "last_update_date": "2026-07-30",
         "requirements": "none",
         "category": "Windows System",
-        "notes": "Modernized from WLEAPP. Times are explicitly device-local "
-                 "because setupapi.dev.log does not record a UTC offset. A "
-                 "section start is not automatically labeled as a device's "
-                 "first connection.",
+        "notes": "Modernized from WLEAPP. Timestamps in setupapi.dev.log "
+                 "carry no UTC offset and are treated as device-local, "
+                 "consistent with Microsoft's documented SetupAPI logging "
+                 "behavior. A section start is not automatically labeled as "
+                 "a device's first connection.",
         "paths": (
             "*/Windows/INF/setupapi.dev.log",
             "*/WINDOWS/INF/setupapi.dev.log",
@@ -322,7 +324,7 @@ def windowsNotifications(context):
         ("Expiry Time (UTC)", "datetime"),
         "Handler Created (database value)",
         "Handler Modified (database value)",
-        ("Boot ID Time (UTC)", "datetime"),
+        "Boot ID (database value)",
         "Notification ID",
         "Handler ID",
         "Handler Primary ID",
@@ -373,7 +375,7 @@ def windowsNotifications(context):
                 _utc_from_filetime(record[1]),
                 record[2] or "",
                 record[3] or "",
-                _utc_from_filetime(record[4]),
+                "" if record[4] is None else record[4],
                 record[5],
                 record[6],
                 record[7] or "",


### PR DESCRIPTION
Fixes from a documentation audit of artifacts touched 2026-07-29/30, applying the standard that notes and descriptions must not state what data means unless the data (or a cited source) proves it.

## Behavior change

**windowsSystem / Notifications**: `Notification.BootId` was converted as a Windows FILETIME and reported as "Boot ID Time (UTC)". Nothing in the repo establishes the field is a timestamp — the lab validation never covered BootId, the unit test only proved the conversion of a synthetic FILETIME it inserted itself, and public wpndatabase research describes BootId as a boot sequence identifier. A real counter value would have rendered as a bogus 1601-era timestamp in front of an examiner. The column is now "Boot ID (database value)", reported as stored, with a test asserting the raw pass-through.

## Documentation-only fixes

- **Notifications note**: the FILETIME/UTC claim now covers only arrival and expiry (lab validated); Boot ID is stated as reported-as-stored.
- **SetupAPI note**: "device-local because the log records no UTC offset" was a fact stated with a justification that doesn't support it (a missing offset shows ambiguity, not local time); now attributed to Microsoft's documented SetupAPI logging behavior.
- **Photos note**: "Alternate Date Taken is an app-maintained fallback" was an unsourced purpose attribution; now described as a separate app-recorded date whose derivation is not documented.
- **Alarms**: "Days of Week (bitmask)" asserted an encoding never established; now "(database value)", and the notes state that Recurring is derived from a nonzero Days of Week only when the source carries no IsRecurring value.

All 10 Windows artifact tests pass; lint gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)