### PR TITLE
ci: add Windows import smoke test

### DIFF
--- a/.github/workflows/windows_smoke.yml
+++ b/.github/workflows/windows_smoke.yml
@@ -1,0 +1,31 @@
+name: Windows Smoke Test
+
+# Imports every artifact module on Windows to catch OS-specific breakage
+# (extracted paths use backslash separators on Windows) that the ubuntu-only
+# lint job cannot. This checks importability, not parsing correctness.
+
+on:
+  pull_request:
+    paths:
+      - '**.py'
+      - 'requirements.txt'
+      - '.github/workflows/windows_smoke.yml'
+  workflow_dispatch:
+
+jobs:
+  windows-smoke:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: python -m pip install --prefer-binary -r requirements.txt
+
+      - name: Import all artifact modules on Windows
+        run: python admin/test/scripts/test_artifact_imports.py


### PR DESCRIPTION
Ports ALEAPP's Windows Smoke Test workflow, byte-identical. It imports every artifact module on windows-latest on each pull request, catching OS-specific breakage (backslash path separators in extracted paths) that the ubuntu-only lint and runtime-contract jobs cannot see.

The script it runs, admin/test/scripts/test_artifact_imports.py, already exists in this repo and is exercised on ubuntu by the runtime contract, so this adds the Windows dimension only. The workflow triggers on its own file, so this PR runs it as its own proof.

Part of a CI leveling pass across the five cores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)