### PR TITLE
fix: bundle stdlib that only artifacts import into frozen builds

### DIFF
--- a/scripts/pyinstaller/dleapp.spec
+++ b/scripts/pyinstaller/dleapp.spec
@@ -12,6 +12,15 @@ a = Analysis(['..\\..\\dleapp.py'],
              binaries=[],
              datas=[('..\\', '.\\scripts')],
              hiddenimports=[
+                # Stdlib that only artifacts import. Artifacts are bundled as data
+                # files and imported from disk at runtime, so PyInstaller's
+                # import-graph analysis never sees these, and it prunes stdlib it
+                # cannot see used (mailbox below is the same case, added earlier).
+                'base64',
+                'email.utils',
+                'plistlib',
+                'struct',
+                'xml.etree.ElementTree',
                 'bencoding',
                 'fitz',
                 'ijson',

--- a/scripts/pyinstaller/dleappGUI.spec
+++ b/scripts/pyinstaller/dleappGUI.spec
@@ -12,6 +12,15 @@ a = Analysis(['..\\..\\dleappGUI.py'],
              binaries=[],
              datas=[('..\\', '.\\scripts'), ('..\\..\\assets', '.\\assets')],
              hiddenimports=[
+                # Stdlib that only artifacts import. Artifacts are bundled as data
+                # files and imported from disk at runtime, so PyInstaller's
+                # import-graph analysis never sees these, and it prunes stdlib it
+                # cannot see used (mailbox below is the same case, added earlier).
+                'base64',
+                'email.utils',
+                'plistlib',
+                'struct',
+                'xml.etree.ElementTree',
                 'bencoding',
                 'fitz',
                 'ijson',

--- a/scripts/pyinstaller/dleappGUI_macOS.spec
+++ b/scripts/pyinstaller/dleappGUI_macOS.spec
@@ -11,6 +11,15 @@ a = Analysis(
     binaries=[],
     datas=[('../', 'scripts'), ('../../assets', 'assets')],
     hiddenimports=[
+        # Stdlib that only artifacts import. Artifacts are bundled as data
+        # files and imported from disk at runtime, so PyInstaller's
+        # import-graph analysis never sees these, and it prunes stdlib it
+        # cannot see used (mailbox below is the same case, added earlier).
+        'base64',
+        'email.utils',
+        'plistlib',
+        'struct',
+        'xml.etree.ElementTree',
         'bencoding',
         'fitz',
         'ijson',

--- a/scripts/pyinstaller/dleapp_macOS.spec
+++ b/scripts/pyinstaller/dleapp_macOS.spec
@@ -11,6 +11,15 @@ a = Analysis(
     binaries=[],
     datas=[('../', 'scripts')],
     hiddenimports=[
+        # Stdlib that only artifacts import. Artifacts are bundled as data
+        # files and imported from disk at runtime, so PyInstaller's
+        # import-graph analysis never sees these, and it prunes stdlib it
+        # cannot see used (mailbox below is the same case, added earlier).
+        'base64',
+        'email.utils',
+        'plistlib',
+        'struct',
+        'xml.etree.ElementTree',
         'bencoding',
         'fitz',
         'ijson',


### PR DESCRIPTION
Pre-flight for the test_builds workflow port, same frozen-build defect class as ALEAPP #1097, RLEAPP #407 and VLEAPP #124: artifacts are bundled as data files and imported from disk at runtime, so PyInstaller's import-graph analysis never sees what they import, and it prunes stdlib it cannot see used.

DLEAPP's third-party coverage was already complete (bs4, pytz, simplekml ride the main graph via ilapfuncs), so the gap here is stdlib only: plistlib, email.utils and xml.etree.ElementTree are imported only by artifacts (the roblox modules among others), with base64 and struct added alongside for the same reason. The existing mailbox entry in these specs is this exact fix applied once by hand.

Verified locally: built dleapp_macOS.spec on Python 3.14 with these changes and ran the frozen CLI end to end (--help plus an empty-input run): 88 modules loaded, exit 0, no import errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)