### PR TITLE
Stop setupapiSections duplicating every row on Windows

### DIFF
--- a/scripts/artifacts/windowsSystem.py
+++ b/scripts/artifacts/windowsSystem.py
@@ -97,7 +97,7 @@ __artifacts_v2__ = {
                        "present, and recorded exit status.",
         "author": "@AlexisBrignoni, Codex",
         "creation_date": "2026-07-29",
-        "last_update_date": "2026-07-30",
+        "last_update_date": "2026-08-19",
         "requirements": "none",
         "category": "Windows System",
         "notes": "Modernized from WLEAPP. Timestamps in setupapi.dev.log "
@@ -106,8 +106,7 @@ __artifacts_v2__ = {
                  "behavior. A section start is not automatically labeled as "
                  "a device's first connection.",
         "paths": (
-            "*/Windows/INF/setupapi.dev.log",
-            "*/WINDOWS/INF/setupapi.dev.log",
+            "*/[Ww][Ii][Nn][Dd][Oo][Ww][Ss]/INF/setupapi.dev.log",
         ),
         "output_types": ["html", "tsv", "timeline", "lava"],
         "artifact_icon": "plug",


### PR DESCRIPTION
`setupapiSections` declared two `paths` patterns differing only in case, `*/Windows/INF/setupapi.dev.log` and `*/WINDOWS/INF/setupapi.dev.log`. `os.path.normcase` folds case on Windows, so those are one pattern there, and the entry point extends `files_found` once per declared pattern with no dedup. The log is read twice and every row is duplicated.

Replaced with a single bracket class, which matches either spelling under both regimes and matches the file exactly once.

Measured against the real seeker with `normcase` set to each platform's implementation, counting `files_found` entries:

| extraction | host | before | after |
| --- | --- | ---: | ---: |
| `Windows` | macOS/Linux | 1 | 1 |
| `Windows` | Windows | 2 | 1 |
| `WINDOWS` | macOS/Linux | 1 | 1 |
| `WINDOWS` | Windows | 2 | 1 |

This is the last thing blocking iLEAPP's `check_artifact_paths.py` guard (iLEAPP #1947) from being levelled here. With this in, DLEAPP passes it.
