### PR TITLE
Record only the image file name in case files

### DIFF
--- a/admin/docs/testing/create_module_test_cases.md
+++ b/admin/docs/testing/create_module_test_cases.md
@@ -67,7 +67,7 @@ The script generates a JSON file (e.g., `testdata.<module_name>.json`) that cont
     "os_name": "iOS",
     "os_version": "12.5.5",
     "make_data": {
-      "input_data_path": "/path/to/iOS12_image.tar.gz",
+      "input_data_path": "iOS12_image.tar.gz",
       "os": "macOS-14.0-...",
       "timestamp": "2024-10-14T10:17:49.432528",
       "last_commit": {
@@ -94,7 +94,7 @@ The script generates a JSON file (e.g., `testdata.<module_name>.json`) that cont
   - `os_name`: Include the name of the operating system this case data originated from (iOS, Android, etc)
   - `os_version`: The specific OS version string (e.g., "12.5.5", "14.1") that this test case represents. `test_module.py` will use this to mock `iOS.get_version()`.
   - `make_data`: Information about the `make_case_data.py` run that generated this case's input data.
-    - `input_data_path`: The path to the original full image/archive used.
+    - `input_data_path`: The file name of the original full image/archive used. Only the name is recorded; the machine-specific location of an image belongs in the git-ignored `admin/image_manifest.local.json`, and `image_name` is what identifies the image.
     - `os`: The operating system on which `make_case_data.py` was run.
     - `timestamp`: The date and time when the input data ZIP was created.
     - `last_commit`: Information about the module's Git commit at the time of data creation.

--- a/admin/test/scripts/make_case_data.py
+++ b/admin/test/scripts/make_case_data.py
@@ -437,7 +437,7 @@ def create_test_data(module_name, image_name=None, case_number=None, input_file=
         "description": "",
         "maker": "",
         "make_data": {
-            "input_data_path": os.path.abspath(input_file),
+            "input_data_path": os.path.basename(input_file),
             "os": platform.platform(),
             "timestamp": datetime.now().isoformat(),
             "last_commit": last_commit_info

--- a/admin/test/scripts/test_case_file_paths.py
+++ b/admin/test/scripts/test_case_file_paths.py
@@ -1,0 +1,35 @@
+"""Structural check: committed case files carry no machine-local paths.
+
+The image manifest split (iLEAPP #2028) keeps machine-independent identity in
+committed files and machine-specific locations in the git-ignored
+admin/image_manifest.local.json. A case entry's make_data.input_data_path is
+display text for the case pickers, which take its basename; recording an
+absolute path there publishes one machine's corpus layout into the repo. This
+guards the make_test_data.py writer and the committed case files together.
+"""
+import glob
+import json
+import os
+import unittest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+CASES_GLOB = os.path.join(REPO_ROOT, 'admin', 'test', 'cases', 'testdata.*.json')
+
+
+class CaseFilePathTests(unittest.TestCase):
+    def test_input_data_path_is_a_bare_file_name(self):
+        offenders = []
+        for path in sorted(glob.glob(CASES_GLOB)):
+            with open(path, encoding='utf-8') as f:
+                cases = json.load(f)
+            for case_key, case in cases.items():
+                value = case.get('make_data', {}).get('input_data_path', '')
+                if '/' in value or '\\' in value:
+                    offenders.append(f"{os.path.basename(path)} [{case_key}]: {value}")
+        self.assertEqual(offenders, [],
+                         "case files must record only the image file name in "
+                         "make_data.input_data_path:\n" + "\n".join(offenders))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Stops the fixture cutter from writing the absolute local path of the input image into committed case files. Matches iLEAPP #2047.

- The cutter records the basename; image locations stay in the git-ignored admin/image_manifest.local.json, and image_name identifies the image.
- A structural test keeps machine-local paths out of the case files. No case files exist here yet, so it starts green.