### PR TITLE
Give the test harness the data folder, so path columns are comparable

### DIFF
--- a/admin/test/scripts/test_module.py
+++ b/admin/test/scripts/test_module.py
@@ -210,6 +210,11 @@ def process_artifact(zip_path, module_name, artifact_name, _artifact_data, targe
             all_artifacts_info = getattr(module, '__artifacts_v2__', {})
             artifact_info = all_artifacts_info.get(artifact_name, {})
 
+            # The case zip is extracted into temp_dir, so temp_dir is this run's
+            # equivalent of the seeker's data folder. Without it get_relative_path
+            # is a no-op here and a path column records the recorder's own
+            # directory instead of the extraction-relative path.
+            Context.set_data_folder(str(temp_dir))
             Context.set_report_folder(str(mock_report_folder_path))
             Context.set_seeker(mock_seeker)
             Context.set_files_found(all_files)

--- a/scripts/context.py
+++ b/scripts/context.py
@@ -38,6 +38,24 @@ class Context:
         Context._data_folder = getattr(output_params, 'data_folder', None)
 
     @staticmethod
+    def set_data_folder(data_folder):
+        """
+        Sets the folder the seeker stages evidence into, without the rest of the
+        output parameters.
+
+        A normal run gets this from set_output_params. The test harness has no
+        OutputParameters: it extracts a case zip into its own temporary directory
+        and runs artifacts against that. Without this, _data_folder stays None and
+        get_relative_path returns every path unchanged, so an artifact that leaks
+        an absolute path and one that reports a relative path record identical
+        output and no fixture can tell them apart.
+
+        Args:
+            data_folder (str): The folder evidence is staged into.
+        """
+        Context._data_folder = data_folder
+
+    @staticmethod
     def set_report_folder(report_folder):
         """
         Sets the report folder path in the Context.


### PR DESCRIPTION
Context.get_relative_path returns its argument unchanged when _data_folder is unset. The harness set the report folder, the seeker and files_found but never the data folder, so inside it that function did nothing: an artifact leaking an absolute path and one reporting an extraction-relative path recorded identical output, and no fixture could tell them apart.

Adds Context.set_data_folder, since the harness has no OutputParameters to pass.

This repo has no committed test cases, so no baseline changes. Added for parity with the iLEAPP and ALEAPP copies.