### PR TITLE
Remove get_sqlite_multiple_db_records, which nothing calls

### DIFF
--- a/scripts/ilapfuncs.py
+++ b/scripts/ilapfuncs.py
@@ -698,27 +698,6 @@ def get_sqlite_db_records(path, query, attach_query=None):
             logfunc(f" - {str(e)}")
     return []
 
-def get_sqlite_multiple_db_records(path_list, query, data_headers):
-    multiple_source_files = len(path_list) > 1
-    source_path = ""
-    data_list = []
-    if multiple_source_files:
-        data_headers = list(data_headers)
-        data_headers.append('Source Path')
-        data_headers = tuple(data_headers)
-        source_path = 'file path in the report below'
-    elif path_list:
-        source_path = path_list[0]
-    for file in path_list:
-        db_records = get_sqlite_db_records(file, query)
-        for record in db_records:
-            if multiple_source_files:
-                modifiable_record = list(record)
-                modifiable_record.append(file)
-                record = tuple(modifiable_record)
-            data_list.append(record)
-    return data_headers, data_list, source_path
-
 def does_column_exist_in_db(path, table_name, col_name):
     '''Checks if a specific col exists'''
     db = open_sqlite_db_readonly(path)


### PR DESCRIPTION
The helper appended the full staged path as a Source Path column value and returned the prose "file path in the report below" as source_path, so it produced both of the defects the lint job now blocks: an examiner filesystem path in a report column, and a string constant where the "located at" line needs real paths.

No artifact in any of the five cores calls it, and ALEAPP has never carried it at all. Removing it is better than repairing it: a repaired version is still an idiom for the next artifact to copy, and the two checks only see code that exists.