### PR TITLE
Scope each claim-language allowlist entry to its term

### DIFF
--- a/admin/scripts/check_claim_language.py
+++ b/admin/scripts/check_claim_language.py
@@ -184,15 +184,27 @@ CHECKED_FIELDS = {
     'notes': NOTES_PATTERN,
 }
 
-# Reviewed exceptions, keyed by (filename, artifact_key, field). Every entry
+# Reviewed exceptions, as (filename, artifact_key, field, term). Each needs a
+# reason. The term is part of the key, so an entry silences the one word it was
+# granted for and never the next claim added to the same text.
 # needs a comment justifying it. See the module docstring before adding one.
 ALLOWLIST = {
     # The match is inside the hedge itself: the description closes with "the
     # cache evicts over time, so this index is a partial record of what the
     # client fetched rather than a complete one". Removing the word would remove
     # the caution it belongs to.
-    ("discordCacheRecords.py", "discordCacheRecords", "description"),
+    ("discordCacheRecords.py", "discordCacheRecords", "description", "complete"),
 }
+
+
+def unallowlisted(filename, artifact_key, field, terms):
+    """The terms no ALLOWLIST entry covers for this field.
+
+    An entry is keyed on the term it was granted for, so allowlisting one word does
+    not pre-approve the next claim somebody adds to the same text.
+    """
+    return [term for term in terms
+            if (filename, str(artifact_key), field, term) not in ALLOWLIST]
 
 STANDARD_NOTE = (
     "Artifact name/description reach the examiner through the HTML report and the LAVA\n"
@@ -267,17 +279,18 @@ def scan_file(path):
                 kept = [hit for hit in hits if not negated(text, hit.start())]
                 negated_count += len(hits) - len(kept)
                 hits = kept
-            terms = [hit.group(0) for hit in hits]
-            if not terms:
+            found = sorted({hit.group(0).lower() for hit in hits})
+            if not found:
                 continue
-            allowlisted = (path.name, str(artifact_key), field) in ALLOWLIST
-            matches.append((path, str(artifact_key), field, text, terms, allowlisted))
+            remaining = unallowlisted(path.name, artifact_key, field, found)
+            matches.append((path, str(artifact_key), field, text,
+                            remaining or found, not remaining, found))
     return matches, None, negated_count
 
 
 def format_match(match):
     """Render one match as `path:artifact_key:field: <text>`."""
-    path, artifact_key, field, text, terms, _ = match
+    path, artifact_key, field, text, terms = match[:5]
     collapsed = " ".join(text.split())
     if len(collapsed) > 300:
         collapsed = collapsed[:297] + "..."
@@ -313,7 +326,8 @@ def main():
             continue
         for match in matches:
             entry = (rel_path,) + match[1:]
-            fired.add((path.name, match[1], match[2]))
+            for term in match[6]:
+                fired.add((path.name, match[1], match[2], term))
             if match[5]:
                 allowlisted.append(entry)
             else:
@@ -346,7 +360,7 @@ def main():
         print(f"Stale ALLOWLIST entr(ies) ({len(stale)}) -- these no longer match "
               f"anything and should be deleted:")
         for entry in stale:
-            print(f"  {entry[0]}:{entry[1]}:{entry[2]}")
+            print(f"  {entry[0]}:{entry[1]}:{entry[2]}  [{entry[3]}]")
         print()
 
     if args.list_all and allowlisted:

--- a/admin/test/scripts/test_check_claim_language.py
+++ b/admin/test/scripts/test_check_claim_language.py
@@ -175,5 +175,46 @@ class Negation(unittest.TestCase):
         self.assertTrue(fires('notes', text))
 
 
+class AllowlistIsTermScoped(unittest.TestCase):
+    """An exception silences the word it was granted for, not the whole field.
+
+    Keyed on (file, artifact_key, field) an entry pre-approves every future claim
+    anyone adds to that text. The term is part of the key so that it does not.
+    """
+
+    def test_every_entry_is_a_four_tuple_of_strings(self):
+        for entry in ccl.ALLOWLIST:
+            with self.subTest(entry=entry):
+                self.assertEqual(len(entry), 4)
+                self.assertTrue(all(isinstance(part, str) for part in entry))
+
+    def test_every_entry_names_a_term_the_vocabulary_can_produce(self):
+        # A term no pattern can emit is dead on arrival: it silences nothing and the
+        # stale check cannot tell it apart from an entry whose text was reworded.
+        for filename, artifact_key, field, term in ccl.ALLOWLIST:
+            with self.subTest(entry=(filename, artifact_key, field, term)):
+                self.assertEqual(term, term.lower())
+                match = ccl.CHECKED_FIELDS[field].search(term)
+                self.assertIsNotNone(match, f'{term!r} is not in the {field} vocabulary')
+                self.assertEqual(match.group(0).lower(), term)
+
+    def test_an_entry_covers_its_own_term_only(self):
+        # A key no repo can hold, so this behaves the same in all five.
+        probe = ('no_such_module.py', 'no_such_artifact', 'notes')
+        self.assertEqual(
+            ccl.unallowlisted(*probe, ['always', 'the user typed']),
+            ['always', 'the user typed'])
+
+    def test_unallowlisted_returns_only_what_is_uncovered(self):
+        for filename, artifact_key, field, term in sorted(ccl.ALLOWLIST):
+            covered = ccl.unallowlisted(filename, artifact_key, field, [term])
+            self.assertEqual(covered, [], f'{term!r} should be covered by its own entry')
+            # A different term on the same field must still be reported.
+            other = 'proves' if term != 'proves' else 'always'
+            self.assertEqual(
+                ccl.unallowlisted(filename, artifact_key, field, [term, other]), [other])
+            break   # one entry is enough; repos with an empty allowlist skip the loop
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Follow-up to the notes claim-checking work. An `ALLOWLIST` entry was keyed on `(file, artifact_key, field)`, so it silenced the whole field: allowlisting one word pre-approved every future claim added to the same text.

- The key now carries the term, so an entry silences the word it was granted for and nothing else.
- A report names only the terms no entry covers, so a new claim in an already-allowlisted note is reported on its own.
- Stale detection compares on the term too, and the message names it.

Existing entries keep their effect: each term was derived from what it silences today, so nothing new is reported. Across the five cores 27 entries become 29 tuples, two of them having covered two terms each.
