### PR TITLE
Close the quote in the CLI version info so dleapp.exe can build again

### DIFF
--- a/scripts/pyinstaller/dleapp-file_version_info.txt
+++ b/scripts/pyinstaller/dleapp-file_version_info.txt
@@ -16,7 +16,7 @@ VSVersionInfo(
         '040904b0',
         [StringStruct('CompanyName', 'Alexis Brignoni'),
         StringStruct('FileDescription', 'DLEAPP CLI'),
-        StringStruct('FileVersion', '2026.3.1-dev),
+        StringStruct('FileVersion', '2026.3.1-dev'),
         StringStruct('InternalName', 'DLEAPP'),
         StringStruct('LegalCopyright', 'Result of a collaborative effort in the DFIR community.'),
         StringStruct('OriginalFilename', 'dleapp.exe'),


### PR DESCRIPTION
`scripts/pyinstaller/dleapp-file_version_info.txt` line 19 is missing its closing quote:

```
StringStruct('FileVersion', '2026.3.1-dev),
```

PyInstaller evaluates that file as Python, so the CLI build fails before it starts:

```
SyntaxError: unterminated string literal (detected at line 19)
ValueError: Failed to deserialize VSVersionInfo from text-based representation!
```

The GUI's copy of the file (`dleappGUI-file_version_info.txt`) has the quote and builds
fine, which is why only `dleapp.exe` is affected.

Introduced in 1687c16 "Update version number to 2026.3.1-dev" (2026-08-17), so the CLI
binary has not been buildable since. It went unnoticed because `test_builds.yml` is
`workflow_dispatch` only — nothing builds the binaries on push, so the break never
surfaced in a PR.

Found while building a local test binary. With this one character restored,
`pyinstaller dleapp.spec` completes and the resulting `dleapp.exe` passes the same smoke
test `test_builds.yml` runs: `--help` exits 0, and a full run against an empty input
directory exits 0 and writes a report with no import errors.

Worth considering separately: the same class of break will recur silently as long as
nothing builds on push. Adding the binary build to a scheduled or pull-request trigger
would have caught this on the commit that introduced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
